### PR TITLE
apollo: Fix clean makefile target

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -74,6 +74,8 @@ SRC_C += $(addprefix $(CURRENT_PATH)/, $(SOURCES))
 # For now, take advantage of the example rules.
 include $(TINYUSB_PATH)/examples/rules.mk
 
+# Reset BUILD to fix clean target
+BUILD := _build
 
 # Flashing using Saturn-V.
 dfu: _build/$(BOARD)/$(BOARD)-firmware.bin


### PR DESCRIPTION
A hopefully simple fix for #1

We can update `BOARD` after `rules.mk` is parsed to adjust the build directory to be removed when executing the clean target.
Because other variables all use immediate assignment `:=` they're not effected when we make this change to `BOARD`.

But due to the way make works, when it goes to actually execute the `clean` target on the second pass `BOARD` is now set to `_build` like we want.