### PR TITLE
Add close method to ApolloDebugger

### DIFF
--- a/apollo_fpga/__init__.py
+++ b/apollo_fpga/__init__.py
@@ -238,3 +238,8 @@ class ApolloDebugger:
             self.out_request(self.REQUEST_FORCE_FPGA_OFFLINE)
         except usb.core.USBError:
             pass
+
+    def close(self):
+        """ Closes the USB device so it can be reused, possibly by another ApolloDebugger """
+
+        usb.util.dispose_resources(self.device)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "apollo-fpga"
-version = "0.0.4"
+version = "0.0.5"
 description = "host tools for Apollo FPGA debug controllers"
 authors = ["Katherine Temkin <k@ktemkin.com>"]
 license = "BSD"


### PR DESCRIPTION
This is necessary to force the release of the USB device without waiting on the Python garbage collector. Without intentionally releasing the USB device, programming fails under Windows because an earlier ApolloDebugger instance already has the USB device open from querying the board version.