### PR TITLE
Flashing improvements

### DIFF
--- a/apollo_fpga/commands/cli.py
+++ b/apollo_fpga/commands/cli.py
@@ -161,6 +161,7 @@ def erase_flash(device, args):
 
 
 def program_flash(device, args):
+    ensure_unconfigured(device)
     with device.jtag as jtag:
         programmer = device.create_jtag_programmer(jtag)
 

--- a/apollo_fpga/commands/cli.py
+++ b/apollo_fpga/commands/cli.py
@@ -174,13 +174,20 @@ def program_flash(device, args):
 def read_back_flash(device, args):
 
     # XXX abstract this?
-    length = ast.literal_eval(args.value) if args.value else (4 * 1024 * 1024)
+    length = 4 * 1024 * 1024
+    offset = 0
+    if args.value:
+        v = ast.literal_eval(args.value)
+        if isinstance(v, int):
+            length = v
+        else:
+            length, offset = v
 
     with device.jtag as jtag:
         programmer = device.create_jtag_programmer(jtag)
 
         with open(args.argument, "wb") as f:
-            bitstream = programmer.read_flash(length)
+            bitstream = programmer.read_flash(length, offset)
             f.write(bitstream)
 
     device.soft_reset()
@@ -328,7 +335,9 @@ def main():
     parser.add_argument('argument', metavar="[argument]", nargs='?',
                         help='the argument to the given command; often a filename')
     parser.add_argument('value', metavar="[value]", nargs='?',
-                        help='the value to a register write command, or the length for flash read')
+                        help='the value to a register write command, or the length for flash read.\n'
+                        'value also accepts (length, offset) for read.\n'
+                        )
 
     args = parser.parse_args()
     device = ApolloDebugger()

--- a/apollo_fpga/commands/cli.py
+++ b/apollo_fpga/commands/cli.py
@@ -167,7 +167,11 @@ def program_flash(device, args):
         with open(args.argument, "rb") as f:
             bitstream = f.read()
 
-        programmer.flash(bitstream)
+        offset = 0
+        if args.value:
+            offset = int(args.value, 0)
+
+        programmer.flash(bitstream, offset=offset)
 
     device.soft_reset()
 
@@ -337,6 +341,7 @@ def main():
     parser.add_argument('value', metavar="[value]", nargs='?',
                         help='the value to a register write command, or the length for flash read.\n'
                         'value also accepts (length, offset) for read.\n'
+                        'value is the offset for a flash write. Up to 64kB beyond the data may also be erased.\n'
                         )
 
     args = parser.parse_args()

--- a/apollo_fpga/ecp5.py
+++ b/apollo_fpga/ecp5.py
@@ -685,7 +685,7 @@ class ECP5CommandBasedProgrammer(ECP5Programmer):
         self.trigger_reconfiguration()
 
 
-    def read_flash(self, length):
+    def read_flash(self, length, offset=0):
         """ Reads the contents of the attached FPGA's configuration flash. """
 
         # Take control of the FPGA's SPI lines.
@@ -696,9 +696,12 @@ class ECP5CommandBasedProgrammer(ECP5Programmer):
         if flash_id in (0x00, 0xFF):
             raise IOError("Flash does not seem correctly connected to the FPGA!")
 
+        if offset % self.SPI_FLASH_PAGE_SIZE != 0:
+            raise IOError(f"Read offset {offset} must be a multiple of {self.SPI_FLASH_PAGE_SIZE}")
+
         # Read our data back , one page at a time.
         data            = bytearray()
-        address         = 0
+        address         = offset
         bytes_remaining = length
 
         while bytes_remaining:

--- a/apollo_fpga/ecp5.py
+++ b/apollo_fpga/ecp5.py
@@ -659,16 +659,20 @@ class ECP5CommandBasedProgrammer(ECP5Programmer):
         # Prepare for writing by erasing the chip.
         # TODO: potentially support more granular erases, here?
         if erase_first:
+            print("Erasing")
             self._enable_writing_to_flash()
             self._background_spi_transfer([self.FlashOpcode.CHIP_ERASE])
             self._flash_wait_for_completion()
+            print("Erase done")
 
         #
         # Finally, program the bitstream itself.
         #
+        print("Writing")
         address = 0
         data_remaining = bytearray(bitstream)
         while data_remaining:
+            print(address)
 
             # Extract a single page of data to program.
             chunk = data_remaining[0:self.SPI_FLASH_PAGE_SIZE]


### PR DESCRIPTION
These are a few improvements I've been using for flashing an OrangeCrab board using Apollo.

It lets Apollo perform partial erases, and write flash to an offset.
`apollo flash bitstream.bit  0x80000`, `apollo flash linux.elf 0x400000` etc

I've been testing on an Adafruit qtpy board. (Will send a pull request for it once a small problem with tinyusb is upstreamed.)