### PR TITLE
Add support for Adafruit qtpy atsamd21 board

### DIFF
--- a/apollo_fpga/__init__.py
+++ b/apollo_fpga/__init__.py
@@ -49,11 +49,13 @@ class ApolloDebugger:
     EXTERNAL_BOARD_MAJOR = 0xFF
     EXTERNAL_BOARD_NAMES = {
         0: "Daisho [rev 31-Oct-2014]",
-        1: "Xil.se Pergola FPGA"
+        1: "Xil.se Pergola FPGA",
+        2: "Adafruit QT Py ATSAMD21E18",
     }
 
     EXTERNAL_BOARD_PROGRAMMERS = {
-        0: IntelJTAGProgrammer
+        0: IntelJTAGProgrammer,
+        2: ECP5_JTAGProgrammer,
     }
 
 

--- a/firmware/src/boards/daisho/tusb_config.h
+++ b/firmware/src/boards/daisho/tusb_config.h
@@ -67,7 +67,7 @@
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC              1
-//#define CFG_TUD_DFU_RT           1
+//#define CFG_TUD_DFU_RUNTIME      1
 #define CFG_TUD_VENDOR           1
 
 // CDC FIFO size of TX and RX

--- a/firmware/src/boards/luna_d11/dfu.c
+++ b/firmware/src/boards/luna_d11/dfu.c
@@ -15,7 +15,7 @@
 /**
  * Handler for DFU_DETACH events, which should cause us to reboot into the bootloader.
  */
-void tud_dfu_rt_reboot_to_dfu(void)
+void tud_dfu_runtime_reboot_to_dfu_cb(void)
 {
 	// The easiest way to reboot into the bootloader is to trigger the watchdog timer.
 	// We'll just enable the WDT and then deliberately hang; which should cause an immediate reset.

--- a/firmware/src/boards/luna_d11/tusb_config.h
+++ b/firmware/src/boards/luna_d11/tusb_config.h
@@ -67,7 +67,7 @@
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC              1
-#define CFG_TUD_DFU_RT           1
+#define CFG_TUD_DFU_RUNTIME      1
 #define CFG_TUD_VENDOR           1
 
 // CDC FIFO size of TX and RX

--- a/firmware/src/boards/luna_d21/dfu.c
+++ b/firmware/src/boards/luna_d21/dfu.c
@@ -15,7 +15,7 @@
 /**
  * Handler for DFU_DETACH events, which should cause us to reboot into the bootloader.
  */
-void tud_dfu_rt_reboot_to_dfu(void)
+void tud_dfu_runtime_reboot_to_dfu_cb(void)
 {
 	// The easiest way to reboot into the bootloader is to trigger the watchdog timer.
 	// We'll just enable the WDT and then deliberately hang; which should cause an immediate reset.

--- a/firmware/src/boards/luna_d21/tusb_config.h
+++ b/firmware/src/boards/luna_d21/tusb_config.h
@@ -67,7 +67,7 @@
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC              1
-#define CFG_TUD_DFU_RT           1
+#define CFG_TUD_DFU_RUNTIME      1
 #define CFG_TUD_VENDOR           1
 
 // CDC FIFO size of TX and RX

--- a/firmware/src/boards/qtpy/apollo_board.h
+++ b/firmware/src/boards/qtpy/apollo_board.h
@@ -1,0 +1,49 @@
+/**
+ * Apollo board definitions for Adafruit QT py
+ *
+ * Copyright (c) 2020 Great Scott Gadgets <info@greatscottgadgets.com>
+ * Copyright (c) 2021 Matt Johnston <matt@ucc.asn.au>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __APOLLO_BOARD_H__
+#define __APOLLO_BOARD_H__
+
+#include <sam.h>
+#include <hal/include/hal_gpio.h>
+#include <stdbool.h>
+
+/**
+ * TODO: the qtpy board has a single RGB neopixel.
+ */
+typedef enum {
+	LED_A,
+	LED_B,
+	LED_C,
+	LED_D,
+	LED_E,
+} led_t;
+
+/**
+ * GPIO pin numbers.
+ */
+
+// NOTE: there is assocated pinmux config in uart.c and spi.c
+// that must be kept in sync with these pins, and SERCOM selection.
+
+enum {
+	// Each of the JTAG pins. SERCOM2
+	TMS_GPIO = PIN_PA02, // A0 qtpy board edge
+	TDI_GPIO = PIN_PA10, // MOSI
+	TDO_GPIO = PIN_PA09, // MISO
+	TCK_GPIO = PIN_PA11, // SCK
+
+	// Connected to orangecrab pins 0 and 1. SERCOM0
+	UART_RX = PIN_PA04, // A2 qtpy
+	UART_TX = PIN_PA06, // A6 qtpy
+
+	// Connected to orangecrab RSTFPGA_RESET, ecp5 PROGRAMN
+	PIN_PROG = PIN_PA03, // A1 qtpy
+};
+
+#endif

--- a/firmware/src/boards/qtpy/board.mk
+++ b/firmware/src/boards/qtpy/board.mk
@@ -1,0 +1,6 @@
+
+# This is an external board, so its identity is determined by its revision number.
+# MAJOR = external board
+# MINOR = generic Apollo board
+BOARD_REVISION_MAJOR := 255
+BOARD_REVISION_MINOR := 2

--- a/firmware/src/boards/qtpy/debug_spi.c
+++ b/firmware/src/boards/qtpy/debug_spi.c
@@ -1,0 +1,36 @@
+/**
+ * Interface code for communicating with the FPGA over the Debug SPI connection.
+ *
+ * This file is part of LUNA.
+ *
+ * Copyright (c) 2020 Great Scott Gadgets <info@greatscottgadgets.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <tusb.h>
+#include <apollo_board.h>
+
+#include <led.h>
+#include <debug_spi.h>
+
+extern uint8_t spi_in_buffer[256 + 4];
+extern uint8_t spi_out_buffer[256 + 4];
+
+
+// Imported internal functions from main debug_spi.c:
+void debug_spi_send(uint8_t *tx_buffer, uint8_t *rx_buffer, size_t length);
+
+
+/**
+ * Request that sends a block of data over our debug SPI.
+ */
+bool handle_flash_spi_send(uint8_t rhport, tusb_control_request_t const* request)
+{
+	return false;
+}
+
+
+bool handle_flash_spi_send_complete(uint8_t rhport, tusb_control_request_t const* request)
+{
+	return false;
+}

--- a/firmware/src/boards/qtpy/dfu.c
+++ b/firmware/src/boards/qtpy/dfu.c
@@ -1,0 +1,24 @@
+/**
+ * DFU Runtime Support
+ *
+ * This file provides support for automatically rebooting into the DFU bootloader.
+ *
+ * This file is part of LUNA.
+ *
+ * Copyright (c) 2020 Great Scott Gadgets <info@greatscottgadgets.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sam.h>
+#include "tusb.h"
+
+/**
+ * Handler for DFU_DETACH events, which should cause us to reboot into the bootloader.
+ */
+void tud_dfu_runtime_reboot_to_dfu_cb(void)
+{
+	// The easiest way to reboot into the bootloader is to trigger the watchdog timer.
+	// We'll just enable the WDT and then deliberately hang; which should cause an immediate reset.
+	REG_WDT_CTRL |= WDT_CTRL_ENABLE;
+	while(1);
+}

--- a/firmware/src/boards/qtpy/fpga.c
+++ b/firmware/src/boards/qtpy/fpga.c
@@ -1,0 +1,71 @@
+/**
+ * Code for basic FPGA interfacing.
+ *
+ * This file is part of LUNA.
+ *
+ * Copyright (c) 2020 Great Scott Gadgets <info@greatscottgadgets.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <bsp/board.h>
+#include <hal/include/hal_gpio.h>
+#include <apollo_board.h>
+
+// List of pins used for FPGA interfacing.
+
+#if 0
+enum {
+	DONE_GPIO    = PIN_PA15,
+	PROGRAM_GPIO = PIN_PA16,
+	INIT_GPIO    = PIN_PA17,
+
+	PIN_PROG =     PIN_PA17
+};
+#endif
+
+
+/**
+ * Sets up the I/O pins needed to configure the FPGA.
+ */
+void fpga_io_init(void)
+{
+	// Unused
+	#if 0
+	// Don't actively drive the FPGA configration pins...
+	gpio_set_pin_direction(DONE_GPIO,    GPIO_DIRECTION_IN);
+	gpio_set_pin_direction(INIT_GPIO,    GPIO_DIRECTION_IN);
+
+	// ... but keep PROGRAM_N out of applying a program...
+	gpio_set_pin_level(PROGRAM_GPIO, true);
+	gpio_set_pin_direction(PROGRAM_GPIO, GPIO_DIRECTION_IN);
+
+	// ... and apply their recommended pull configuration.
+	gpio_set_pin_pull_mode(PROGRAM_GPIO, GPIO_PULL_UP);
+	gpio_set_pin_pull_mode(DONE_GPIO,    GPIO_PULL_UP);
+	#endif
+}
+
+
+/**
+ * Requests that the FPGA clear its configuration and try to reconfigure.
+ */
+void trigger_fpga_reconfiguration(void)
+{
+	gpio_set_pin_direction(PIN_PROG, GPIO_DIRECTION_OUT);
+	gpio_set_pin_level(PIN_PROG, false);
+
+	board_delay(1);
+
+	gpio_set_pin_level(PIN_PROG, true);
+	gpio_set_pin_direction(PIN_PROG, GPIO_DIRECTION_IN);
+}
+
+
+/**
+ * Requests that we hold the FPGA in an unconfigured state.
+ */
+void force_fpga_offline(void)
+{
+	gpio_set_pin_direction(PIN_PROG, GPIO_DIRECTION_OUT);
+	gpio_set_pin_level(PIN_PROG, false);
+}

--- a/firmware/src/boards/qtpy/jtag.c
+++ b/firmware/src/boards/qtpy/jtag.c
@@ -1,0 +1,85 @@
+/**
+ * This file is part of LUNA.
+ *
+ * Copyright (c) 2020 Great Scott Gadgets <info@greatscottgadgets.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+
+#include <tusb.h>
+#include <apollo_board.h>
+#include "spi.h"
+
+#include <jtag.h>
+
+extern uint8_t jtag_in_buffer[256];
+extern uint8_t jtag_out_buffer[256];
+
+
+/**
+ * Hook that performs hardware-specific initialization.
+ */
+void jtag_platform_init(void)
+{
+	// Ensure the TDO GPIO is continuously sampled, rather
+	// than sampled on-demand. This allows us to significantly
+	// speak up TDO reads.
+	PORT->Group[0].CTRL.reg = (1 << TDO_GPIO);
+
+	// Set up our SPI port for SPI-accelerated JTAG.
+	spi_init(SPI_FPGA_JTAG, true, false, 1, 1, 1);
+}
+
+
+/**
+ * Hook that performs hardware-specific deinitialization.
+ */
+void jtag_platform_deinit(void)
+{
+}
+
+
+/**
+ * Request that performs the actual JTAG scan event.
+ * Arguments:
+ *     wValue: the number of bits to scan; total
+ *     wIndex: 1 if the given command should advance the FSM
+ */
+bool handle_jtag_request_scan(uint8_t rhport, tusb_control_request_t const* request)
+{
+	// Our bulk method can only send whole bytes; so send as many bytes as we can
+	// using the fast method; and then send the remainder using our slow method.
+	size_t bytes_to_send_bulk = request->wValue / 8;
+	size_t bits_to_send_slow  = request->wValue % 8;
+
+	// We can't handle 0-byte transfers; fail out.
+	if (!bits_to_send_slow && !bytes_to_send_bulk) {
+		return false;
+	}
+
+	// If this would scan more than we have buffer for, fail out.
+	if (bytes_to_send_bulk > sizeof(jtag_out_buffer)) {
+		return false;
+	}
+
+	// If we're going to advance state, always make sure the last bit is sent using the slow method,
+	// so we can handle JTAG TAP state advancement on the last bit. If we don't have any bits to send slow,
+	// send the last byte slow.
+	if (!bits_to_send_slow && request->wIndex) {
+		bytes_to_send_bulk--;
+		bits_to_send_slow = 8;
+	}
+
+	// Switch to SPI mode, and send the bulk of the transfer using it.
+	spi_configure_pinmux(SPI_FPGA_JTAG);
+	spi_send(SPI_FPGA_JTAG, jtag_out_buffer, jtag_in_buffer, bytes_to_send_bulk);
+
+	// Switch back to GPIO mode, and send the remainder using the slow method.
+	spi_release_pinmux(SPI_FPGA_JTAG);
+	if (bits_to_send_slow) {
+		jtag_tap_shift(jtag_out_buffer + bytes_to_send_bulk, jtag_in_buffer + bytes_to_send_bulk,
+				bits_to_send_slow, request->wIndex);
+	}
+	return tud_control_xfer(rhport, request, NULL, 0);
+}
+

--- a/firmware/src/boards/qtpy/led.c
+++ b/firmware/src/boards/qtpy/led.c
@@ -1,0 +1,163 @@
+/*
+ * LED control abstraciton code.
+ *
+ * This file is part of LUNA.
+ *
+ * Copyright (c) 2020 Great Scott Gadgets <info@greatscottgadgets.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include <tusb.h>
+#include <sam.h>
+#include <bsp/board.h>
+#include <hal/include/hal_gpio.h>
+
+
+#include "led.h"
+
+
+/** Store the current LED blink pattern. */
+static blink_pattern_t blink_pattern = BLINK_IDLE;
+
+
+/**
+ * Sets the active LED blink pattern.
+ */
+void led_set_blink_pattern(blink_pattern_t pattern)
+{
+	blink_pattern = pattern;
+	leds_off();
+}
+
+
+/**
+ * Sets up each of the LEDs for use.
+ */
+void led_init(void)
+{
+	// uint8_t pins[] = { LED_A, LED_B, LED_C, LED_D, LED_E };
+
+	// Default each LED to an output and _off_.
+}
+
+
+/**
+ * Turns the provided LED on.
+ */
+void led_on(led_t led)
+{
+}
+
+
+/**
+ * Turns the provided LED off.
+ */
+void led_off(led_t led)
+{
+}
+
+
+/**
+ * Toggles the provided LED.
+ */
+void led_toggle(led_t led)
+{
+}
+
+
+/**
+ * Sets whether a given led is on.
+ */
+void led_set(led_t led, bool on)
+{
+}
+
+
+/**
+ * Turns off all of the device's LEDs.
+ */
+void leds_off(void)
+{
+  led_t leds[] = {LED_A, LED_B, LED_C, LED_D, LED_E};
+
+  for (unsigned i = 0; i < 5; ++i) {
+    led_off(leds[i]);
+  }
+}
+
+
+/**
+ * Turns on the given LED.
+ */
+static void display_led_number(uint8_t number)
+{
+  led_t leds[] = {LED_A, LED_B, LED_C, LED_D, LED_E};
+
+  if (number < 5) {
+    led_on(leds[number]);
+  }
+}
+
+
+/**
+ * Task that handles blinking the heartbeat LED.
+ */
+void heartbeat_task(void)
+{
+  static uint32_t start_ms = 0;
+  static uint8_t active_led = 0;
+  static bool count_up = true;
+
+  // Blink every interval ms
+  if ( board_millis() - start_ms < blink_pattern) return; // not enough time
+  start_ms += blink_pattern;
+
+  switch (blink_pattern) {
+
+    // Standard blink pattern for when the device is idle.
+    // Indicates that the device's JTAG lines are un-pulled.
+    case BLINK_IDLE:
+      led_toggle(LED_E);
+      break;
+
+    // Blink patterns for when the device is being used for JTAG
+    // operation. When these are on, the uC is driving the JTAG lines,
+    // so the JTAG header probably shouldn't used to drive the lines.
+    case BLINK_JTAG_CONNECTED:
+    case BLINK_JTAG_UPLOADING:
+
+      // Sweep back and forth.
+      if (active_led == 0xFF) {
+        count_up = true;
+      }
+      if (active_led == 4) {
+        count_up = false;
+      }
+      active_led = count_up ? active_led + 1  : active_led - 1;
+
+      leds_off();
+      display_led_number(active_led);
+      display_led_number(active_led + 1);
+
+      break;
+
+    // Blink patterns for when the device is being used for SPI flash access.
+    // When these are displayed,
+    case BLINK_FLASH_CONNECTED:
+
+      if (active_led == 5) {
+        active_led = 0;
+      }
+
+      leds_off();
+      display_led_number(active_led++);
+
+      break;
+
+  }
+}

--- a/firmware/src/boards/qtpy/platform_jtag.h
+++ b/firmware/src/boards/qtpy/platform_jtag.h
@@ -1,0 +1,44 @@
+/**
+ * Platform-specific JTAG I/O helpers.
+ * Using these rather than the raw GPIO functions allows read optimizations.
+ *
+ * Copyright (c) 2020 Great Scott Gadgets <info@greatscottgadgets.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+
+#ifndef __PLATFORM_JTAG_H__
+#define __PLATFORM_JTAG_H__
+
+#include <apollo_board.h>
+
+static inline void jtag_set_tms(void)
+{
+	PORT_IOBUS->Group[0].OUTSET.reg = (1 << TMS_GPIO);
+}
+
+
+static inline void jtag_clear_tms(void)
+{
+	PORT_IOBUS->Group[0].OUTCLR.reg = (1 << TMS_GPIO);
+}
+
+
+static inline void jtag_set_tdi(void)
+{
+	PORT_IOBUS->Group[0].OUTSET.reg = (1 << TDI_GPIO);
+}
+
+
+static inline void jtag_clear_tdi(void)
+{
+	PORT_IOBUS->Group[0].OUTCLR.reg = (1 << TDI_GPIO);
+}
+
+
+static inline bool jtag_read_tdo(void)
+{
+	return PORT_IOBUS->Group[0].IN.reg & (1 << TDO_GPIO);
+}
+
+#endif

--- a/firmware/src/boards/qtpy/spi.c
+++ b/firmware/src/boards/qtpy/spi.c
@@ -1,0 +1,202 @@
+/*
+ * SPI driver code.
+ *
+ * This file is part of LUNA.
+ *
+ * Copyright (c) 2020 Great Scott Gadgets <info@greatscottgadgets.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sam.h>
+
+#include <hpl/pm/hpl_pm_base.h>
+#include <hpl/gclk/hpl_gclk_base.h>
+#include <hal/include/hal_gpio.h>
+
+#include "spi.h"
+#include "led.h"
+
+#include <bsp/board.h>
+
+
+// Hide the ugly Atmel Sercom object name.
+typedef Sercom sercom_t;
+
+/**
+ * Returns the SERCOM object associated with the given target.
+ */
+static sercom_t *sercom_for_target(spi_target_t target)
+{
+	switch (target) {
+		case SPI_FPGA_JTAG:  return SERCOM2;
+		case SPI_FPGA_DEBUG: return NULL;
+	}
+
+	return NULL;
+}
+
+
+/**
+ * Pinmux the relevent pins so the can be used for SERCOM SPI.
+ */
+static void _spi_configure_pinmux(spi_target_t target, bool use_for_spi)
+{
+	switch (target) {
+
+		// FPGA JTAG connection -- configure TDI, TCK, TDO
+		case SPI_FPGA_JTAG:
+			if (use_for_spi) {
+				// SERCOM DI pad1, DO pad2, SCK pad3
+				// TDI
+				gpio_set_pin_function(PIN_PA10, MUX_PA10D_SERCOM2_PAD2);
+				// TCK
+				gpio_set_pin_function(PIN_PA11, MUX_PA11D_SERCOM2_PAD3);
+				// TDO
+				gpio_set_pin_function(PIN_PA09, MUX_PA09D_SERCOM2_PAD1);
+			} else {
+				gpio_set_pin_function(PIN_PA09, GPIO_PIN_FUNCTION_OFF);
+				gpio_set_pin_function(PIN_PA11, GPIO_PIN_FUNCTION_OFF);
+				gpio_set_pin_function(PIN_PA10, GPIO_PIN_FUNCTION_OFF);
+			}
+			break;
+		case SPI_FPGA_DEBUG:
+			// not implemented
+			break;
+	}
+}
+
+
+/**
+ * Configures the relevant SPI target's pins to be used for SPI.
+ */
+void spi_configure_pinmux(spi_target_t target)
+{
+	_spi_configure_pinmux(target, true);
+}
+
+
+/**
+ * Returns the relevant SPI target's pins to being used for GPIO.
+ */
+void spi_release_pinmux(spi_target_t target)
+{
+	_spi_configure_pinmux(target, false);
+}
+
+
+/**
+ * Configures the clocking for the relevant SERCOM peripheral.
+ */
+static void spi_set_up_clocking(spi_target_t target)
+{
+	switch (target) {
+
+		case SPI_FPGA_JTAG:
+			_pm_enable_bus_clock(PM_BUS_APBC, SERCOM2);
+			_gclk_enable_channel(SERCOM2_GCLK_ID_CORE, GCLK_CLKCTRL_GEN_GCLK0_Val);
+			break;
+
+		case SPI_FPGA_DEBUG:
+			_pm_enable_bus_clock(PM_BUS_APBC, SERCOM2);
+			_gclk_enable_channel(SERCOM2_GCLK_ID_CORE, GCLK_CLKCTRL_GEN_GCLK0_Val);
+			break;
+	}
+
+	// Wait for the clock to be ready.
+	while(GCLK->STATUS.bit.SYNCBUSY);
+}
+
+
+/**
+ * Configures the provided target to be used as an SPI port via the SERCOM.
+ */
+void spi_init(spi_target_t target, bool lsb_first, bool configure_pinmux, uint8_t baud_divider,
+	 uint8_t clock_polarity, uint8_t clock_phase)
+{
+	volatile sercom_t *sercom = sercom_for_target(target);
+
+	// Disable the SERCOM before configuring it, to 1) ensure we're not transacting
+	// during configuration; and 2) as many of the registers are R/O when the SERCOM is enabled.
+	while(sercom->SPI.SYNCBUSY.bit.ENABLE);
+	sercom->SPI.CTRLA.bit.ENABLE = 0;
+
+	// Software reset the SERCOM to restore initial values.
+	while(sercom->SPI.SYNCBUSY.bit.SWRST);
+	sercom->SPI.CTRLA.bit.SWRST = 1;
+
+	// The SWRST bit becomes accessible again once the software reset is
+	// complete -- we'll use this to wait for the reset to be finshed.
+	while(sercom->SPI.SYNCBUSY.bit.SWRST);
+
+	// Ensure we can work with the full SERCOM.
+	while(sercom->SPI.SYNCBUSY.bit.SWRST || sercom->SPI.SYNCBUSY.bit.ENABLE);
+
+	// Pinmux the relevant pins to be used for the SERCOM.
+	if (configure_pinmux) {
+		spi_configure_pinmux(target);
+	}
+
+	// Set up clocking for the SERCOM peripheral.
+	spi_set_up_clocking(target);
+
+	// Configure the SERCOM for SPI master mode.
+	sercom->SPI.CTRLA.reg =
+		SERCOM_SPI_CTRLA_MODE_SPI_MASTER  |  // SPI master
+		// SERCOM DI pad1, DO pad2, SCK pad3
+		SERCOM_SPI_CTRLA_DOPO(1)          |
+		SERCOM_SPI_CTRLA_DIPO(1)          |
+		(lsb_first ? SERCOM_SPI_CTRLA_DORD : 0);   // SPI byte order
+
+	// Set the clock polarity and phase.
+	sercom->SPI.CTRLA.bit.CPOL = clock_polarity;
+	sercom->SPI.CTRLA.bit.CPHA = clock_phase;
+
+	// Use the SPI transceiver.
+	while(sercom->SPI.SYNCBUSY.bit.CTRLB);
+	sercom->SPI.CTRLB.reg = SERCOM_SPI_CTRLB_RXEN;
+
+	// Set the baud divider for the relevant channel.
+	sercom->SPI.BAUD.reg = baud_divider;
+
+	// Finally, enable the SPI controller.
+	sercom->SPI.CTRLA.reg |= SERCOM_SPI_CTRLA_ENABLE;
+	while(sercom->SPI.SYNCBUSY.bit.ENABLE);
+}
+
+
+/**
+ * Synchronously send a single byte on the given SPI bus.
+ * Does not manage the SSEL line.
+ */
+uint8_t spi_send_byte(spi_target_t port, uint8_t data)
+{
+	volatile sercom_t *sercom = sercom_for_target(port);
+
+	// Send the relevant data...
+	while(sercom->SPI.INTFLAG.bit.DRE == 0);
+	sercom->SPI.DATA.reg = data;
+
+	// ... and receive the response.
+	while(sercom->SPI.INTFLAG.bit.RXC == 0);
+	return (uint8_t)sercom->SPI.DATA.reg;
+}
+
+
+/**
+ * Sends a block of data over the SPI bus.
+ *
+ * @param port The port on which to perform the SPI transaction.
+ * @param data_to_send The data to be transferred over the SPI bus.
+ * @param data_received Any data received during the SPI transaction.
+ * @param length The total length of the data to be exchanged, in bytes.
+ */
+void spi_send(spi_target_t port, void *data_to_send, void *data_received, size_t length)
+{
+	uint8_t *to_send  = data_to_send;
+	uint8_t *received = data_received;
+
+	// TODO: use the FIFO to bulk send data
+	for (unsigned i = 0; i < length; ++i) {
+		received[i] = spi_send_byte(port, to_send[i]);
+	}
+}

--- a/firmware/src/boards/qtpy/spi.h
+++ b/firmware/src/boards/qtpy/spi.h
@@ -1,0 +1,59 @@
+/*
+ * SPI driver code.
+ *
+ * This file is part of LUNA.
+ *
+ * Copyright (c) 2020 Great Scott Gadgets <info@greatscottgadgets.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __SPI_H__
+#define __SPI_H__
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef enum {
+	 SPI_FPGA_JTAG,
+	 SPI_FPGA_DEBUG
+ } spi_target_t;
+
+
+/**
+ * Configures the relevant SPI target's pins to be used for SPI.
+ */
+void spi_configure_pinmux(spi_target_t target);
+
+
+/**
+ * Returns the relevant SPI target's pins to being used for GPIO.
+ */
+void spi_release_pinmux(spi_target_t target);
+
+
+/**
+ * Configures the provided target to be used as an SPI port via the SERCOM.
+ */
+void spi_init(spi_target_t target, bool lsb_first, bool configure_pinmux, uint8_t baud_divider,
+	 uint8_t clock_polarity, uint8_t clock_phase);
+
+
+/**
+ * Synchronously send a single byte on the given SPI bus.
+ * Does not manage the SSEL line.
+ */
+uint8_t spi_send_byte(spi_target_t port, uint8_t data);
+
+
+/**
+ * Sends a block of data over the SPI bus.
+ * 
+ * @param port The port on which to perform the SPI transaction.
+ * @param data_to_send The data to be transferred over the SPI bus.
+ * @param data_received Any data received during the SPI transaction.
+ * @param length The total length of the data to be exchanged, in bytes.
+ */
+void spi_send(spi_target_t port, void *data_to_send, void *data_received, size_t length);
+
+#endif

--- a/firmware/src/boards/qtpy/tusb_config.h
+++ b/firmware/src/boards/qtpy/tusb_config.h
@@ -1,0 +1,88 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef _TUSB_CONFIG_H_
+#define _TUSB_CONFIG_H_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+//--------------------------------------------------------------------
+// COMMON CONFIGURATION
+//--------------------------------------------------------------------
+
+// defined by compiler flags for flexibility
+#ifndef CFG_TUSB_MCU
+  #error CFG_TUSB_MCU must be defined
+#endif
+
+#define CFG_TUSB_RHPORT0_MODE       OPT_MODE_DEVICE
+#define CFG_TUSB_OS                 OPT_OS_NONE
+
+/* USB DMA on some MCUs can only access a specific SRAM region with restriction on alignment.
+ * Tinyusb use follows macros to declare transferring memory so that they can be put
+ * into those specific section.
+ * e.g
+ * - CFG_TUSB_MEM SECTION : __attribute__ (( section(".usb_ram") ))
+ * - CFG_TUSB_MEM_ALIGN   : __attribute__ ((aligned(4)))
+ */
+#ifndef CFG_TUSB_MEM_SECTION
+#define CFG_TUSB_MEM_SECTION
+#endif
+
+#ifndef CFG_TUSB_MEM_ALIGN
+#define CFG_TUSB_MEM_ALIGN          __attribute__ ((aligned(4)))
+#endif
+
+//--------------------------------------------------------------------
+// DEVICE CONFIGURATION
+//--------------------------------------------------------------------
+#ifndef CFG_TUD_ENDPOINT0_SIZE
+#define CFG_TUD_ENDPOINT0_SIZE    64
+#endif
+
+
+//------------- CLASS -------------//
+#define CFG_TUD_CDC              1
+#define CFG_TUD_DFU_RUNTIME      1
+#define CFG_TUD_VENDOR           1
+
+// CDC FIFO size of TX and RX
+#define CFG_TUD_VENDOR_RX_BUFSIZE   16
+#define CFG_TUD_VENDOR_TX_BUFSIZE   512
+
+
+// CDC FIFO size of TX and RX
+#define CFG_TUD_CDC_RX_BUFSIZE   64
+#define CFG_TUD_CDC_TX_BUFSIZE   64
+
+
+
+#ifdef __cplusplus
+ }
+#endif
+
+#endif /* _TUSB_CONFIG_H_ */

--- a/firmware/src/boards/qtpy/uart.c
+++ b/firmware/src/boards/qtpy/uart.c
@@ -1,0 +1,190 @@
+/**
+ * UART driver code.
+ *
+ * This file is part of LUNA.
+ *
+ * Copyright (c) 2020 Great Scott Gadgets <info@greatscottgadgets.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+
+#include <sam.h>
+
+#include <hpl/pm/hpl_pm_base.h>
+#include <hpl/gclk/hpl_gclk_base.h>
+#include <hal/include/hal_gpio.h>
+
+#include <peripheral_clk_config.h>
+
+
+// Hide the ugly Atmel Sercom object name.
+typedef Sercom sercom_t;
+
+
+// Create a quick reference to our SERCOM object.
+static sercom_t *sercom = SERCOM0;
+
+// Keep track of whether our UART has been configured and is active.
+bool uart_active = false;
+
+
+/**
+ * Pinmux the relevent pins so the can be used for SERCOM UART.
+ */
+static void _uart_configure_pinmux(bool use_for_uart)
+{
+	if (use_for_uart) {
+		gpio_set_pin_function(PIN_PA04, MUX_PA04D_SERCOM0_PAD0); // RX pad0
+		gpio_set_pin_function(PIN_PA06, MUX_PA06D_SERCOM0_PAD2); // TX pad2
+	} else {
+		gpio_set_pin_function(PIN_PA04, GPIO_PIN_FUNCTION_OFF);
+		gpio_set_pin_function(PIN_PA05, GPIO_PIN_FUNCTION_OFF);
+	}
+}
+
+
+/**
+ * Configures the relevant UART's target's pins to be used for UART.
+ */
+void uart_configure_pinmux(void)
+{
+	_uart_configure_pinmux(true);
+	uart_active = true;
+}
+
+
+/**
+ * Releases the relevant pins from being used for UART, returning them
+ * to use as GPIO.
+ */
+void uart_release_pinmux(void)
+{
+	_uart_configure_pinmux(false);
+	uart_active = false;
+}
+
+
+/**
+ * Configures the UART we'll use for our system console.
+ * TODO: support more configuration (parity, stop, etc.)
+ */
+void uart_init(bool configure_pinmux, unsigned long baudrate)
+{
+	// Disable the SERCOM before configuring it, to 1) ensure we're not transacting
+	// during configuration; and 2) as many of the registers are R/O when the SERCOM is enabled.
+	while(sercom->USART.SYNCBUSY.bit.ENABLE);
+	sercom->USART.CTRLA.bit.ENABLE = 0;
+
+	// Software reset the SERCOM to restore initial values.
+	while(sercom->USART.SYNCBUSY.bit.SWRST);
+	sercom->USART.CTRLA.bit.SWRST = 1;
+
+	// The SWRST bit becomes accessible again once the software reset is
+	// complete -- we'll use this to wait for the reset to be finshed.
+	while(sercom->USART.SYNCBUSY.bit.SWRST);
+
+	// Ensure we can work with the full SERCOM.
+	while(sercom->USART.SYNCBUSY.bit.SWRST || sercom->USART.SYNCBUSY.bit.ENABLE);
+
+	// Pinmux the relevant pins to be used for the SERCOM.
+	if (configure_pinmux) {
+		uart_configure_pinmux();
+	}
+
+	// Set up clocking for the SERCOM peripheral.
+	_pm_enable_bus_clock(PM_BUS_APBC, sercom);
+	_gclk_enable_channel(SERCOM0_GCLK_ID_CORE, GCLK_CLKCTRL_GEN_GCLK0_Val);
+
+	// Configure the SERCOM for UART mode.
+	sercom->USART.CTRLA.reg =
+		SERCOM_USART_CTRLA_DORD            |  // LSB first
+		SERCOM_USART_CTRLA_TXPO(1)         |  // TX on pad2
+		SERCOM_USART_CTRLA_RXPO(0)         |  // RX on pad0
+		SERCOM_USART_CTRLA_SAMPR(0)        |  // use 16x oversampling
+		SERCOM_USART_CTRLA_RUNSTDBY        |  // don't autosuspend the clock
+		SERCOM_USART_CTRLA_MODE_USART_INT_CLK; // use internal clock
+
+	// Configure our baud divisor.
+	// From Atmel:
+	float baud = 65536 * (float)(CONF_CPU_FREQUENCY - 16 * baudrate) / (float)CONF_CPU_FREQUENCY;
+	sercom->USART.BAUD.reg = baud;
+
+	// Configure TX/RX and framing.
+	sercom->USART.CTRLB.reg =
+			SERCOM_USART_CTRLB_CHSIZE(0) | // 8-bit words
+			SERCOM_USART_CTRLB_TXEN      | // Enable TX.
+			SERCOM_USART_CTRLB_RXEN;       // Enable RX.
+
+
+	// Wait for our changes to apply.
+	while (sercom->USART.SYNCBUSY.bit.CTRLB);
+
+	// Enable our receive interrupt, as we want to asynchronously dump data into
+	// the UART console.
+	sercom->USART.INTENSET.reg = SERCOM_USART_INTENSET_RXC;
+
+	// Enable the UART IRQ.
+	NVIC_EnableIRQ(SERCOM0_IRQn);
+
+	// Finally, enable the SERCOM.
+	sercom->USART.CTRLA.bit.ENABLE = 1;
+	while(sercom->USART.SYNCBUSY.bit.ENABLE);
+
+}
+
+
+/**
+ * Callback issued when the UART recieves a new byte.
+ */
+__attribute__((weak)) void uart_byte_received_cb(uint8_t byte) {}
+
+
+/**
+ * UART interrupt handler.
+ */
+void SERCOM0_Handler(void)
+{
+	// If we've just received a character, handle it.
+	if (sercom->USART.INTFLAG.bit.RXC)
+	{
+		// Read the relevant character, which marks this interrupt
+		// as serviced.
+		uint16_t byte = sercom->USART.DATA.reg;
+		uart_byte_received_cb(byte);
+	}
+}
+
+
+
+/**
+ * @return True iff the UART can accept data.
+ */
+bool uart_ready_for_write(void)
+{
+	return (sercom->USART.INTFLAG.reg & SERCOM_USART_INTFLAG_DRE);
+}
+
+
+/**
+ * Starts a write over the Apollo console UART.
+
+ * Does not check for readiness; it is assumed the caller knows that the
+ * UART is avaiable (e.g. by calling uart_ready_for_write).
+ */
+void uart_nonblocking_write(uint8_t byte)
+{
+	sercom->USART.DATA.reg = byte;
+}
+
+
+
+/**
+ * Writes a byte over the Apollo console UART.
+ *
+ * @param byte The byte to be written.
+ */
+void uart_blocking_write(uint8_t byte)
+{
+	while(!uart_ready_for_write());
+	uart_nonblocking_write(byte);
+}

--- a/firmware/src/boards/qtpy/usb_descriptors.c
+++ b/firmware/src/boards/qtpy/usb_descriptors.c
@@ -1,0 +1,199 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Katherine J. Temkin <kate@ktemkin.com>
+ * Copyright (c) 2019 Great Scott Gadgets <ktemkin@greatscottgadgets.com>
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include "tusb.h"
+
+#define SERIAL_NUMBER_STRING_INDEX 3
+
+//--------------------------------------------------------------------+
+// Device Descriptors
+//--------------------------------------------------------------------+
+tusb_desc_device_t const desc_device =
+{
+	.bLength            = sizeof(tusb_desc_device_t),
+	.bDescriptorType    = TUSB_DESC_DEVICE,
+	.bcdUSB             = 0x0200,
+
+	// Use Interface Association Descriptor (IAD) for CDC
+	// As required by USB Specs IAD's subclass must be common class (2) and protocol must be IAD (1)
+	.bDeviceClass       = TUSB_CLASS_MISC,
+	.bDeviceSubClass    = MISC_SUBCLASS_COMMON,
+	.bDeviceProtocol    = MISC_PROTOCOL_IAD,
+
+	.bMaxPacketSize0    = CFG_TUD_ENDPOINT0_SIZE,
+
+	// These are a unique VID/PID for development LUNA boards.
+	.idVendor           = 0x1d50,
+	.idProduct          = 0x615c,
+	.bcdDevice          = (_BOARD_REVISION_MAJOR_ << 8) | _BOARD_REVISION_MINOR_,
+
+	.iManufacturer      = 0x01,
+	.iProduct           = 0x02,
+	.iSerialNumber      = SERIAL_NUMBER_STRING_INDEX,
+
+	.bNumConfigurations = 0x01
+};
+
+// Invoked when received GET DEVICE DESCRIPTOR
+// Application return pointer to descriptor
+uint8_t const * tud_descriptor_device_cb(void)
+{
+	return (uint8_t const *) &desc_device;
+}
+
+//--------------------------------------------------------------------+
+// Configuration Descriptor
+//--------------------------------------------------------------------+
+
+enum
+{
+	ITF_NUM_CDC = 0,
+	ITF_NUM_CDC_DATA,
+	ITF_NUM_DFU_RT,
+	ITF_NUM_TOTAL
+};
+
+#define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN + TUD_DFU_RT_DESC_LEN)
+
+
+uint8_t const desc_configuration[] =
+{
+	// Interface count, string index, total length, attribute, power in mA
+	TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+
+	// Interface number, string index, EP notification address and size, EP data address (out, in) and size.
+	TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, 0x81, 8, 0x02, 0x83, 64),
+
+	// Interface descriptor for the DFU runtime interface.
+	TUD_DFU_RT_DESCRIPTOR(ITF_NUM_DFU_RT, 5, 0x0d, 500, 4096),
+};
+
+
+// Invoked when received GET CONFIGURATION DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const * tud_descriptor_configuration_cb(uint8_t index)
+{
+	(void) index; // for multiple configurations
+	return desc_configuration;
+}
+
+//--------------------------------------------------------------------+
+// String Descriptors
+//--------------------------------------------------------------------+
+
+
+// array of pointer to string descriptors
+char const* string_desc_arr [] =
+{
+	(const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
+	"Great Scott Gadgets",         // 1: Manufacturer
+	"Apollo FPGA programmer, QT Py", // 2: Product
+	NULL,                          // 3: Serials, should use chip ID
+	"UART Bridge",                 // 4: CDC Interface
+	"DFU Runtime"                  // 5: DFU Interface
+};
+
+static uint16_t _desc_str[34];
+
+
+/**
+ * Returns a USB string descriptor that describes this device's unique ID.
+ */
+static uint16_t *get_serial_number_string_descriptor(void)
+{
+	const unsigned serial_number_chars = 32;
+
+	int count = 0;
+
+	//
+	// Read and save the device serial number as normal Base32.
+	//
+
+	// Documented in section 9.3.3 of D21 datasheet, page 32 (rev G), but no header file,
+	// these are not contiguous addresses.
+	const uint32_t	*ser[4] = {
+		(uint32_t *)0x0080A00C,
+		(uint32_t *)0x0080A040,
+		(uint32_t *)0x0080A044,
+		(uint32_t *)0x0080A048
+	};
+
+	// Populate the length and string type, as these are the first two bytes
+	// of our descriptor...
+	_desc_str[count++] = (TUSB_DESC_STRING << 8 ) | ((serial_number_chars * 2) + 2);;
+
+	// ... and convert our serial number into hex.
+	for (unsigned i = 0; i < 32; ++i) {
+		uint32_t word  = *ser[i / 8];
+		uint32_t hexit = word >> ((i % 8) * 4);
+		_desc_str[count++] = "0123456789abcdef"[hexit & 0xF];
+	}
+
+	return _desc_str;
+}
+
+// Invoked when received GET STRING DESCRIPTOR request
+// Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
+uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid)
+{
+	uint8_t chr_count;
+
+	// If we're looking for the "supported languages" descriptor, return it directly.
+	if (index == 0) {
+		memcpy(&_desc_str[1], string_desc_arr[0], 2);
+		chr_count = 1;
+	}
+	//  If this is a request for the serial number, return the device's unique ID>
+	else if (index == SERIAL_NUMBER_STRING_INDEX) {
+		return get_serial_number_string_descriptor();
+	}
+
+	// Otherwise, take the ASCII string provided and encode it as UTF-16.
+	else {
+
+	if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) {
+		return NULL;
+	}
+
+	const char* str = string_desc_arr[index];
+
+	// Cap at max char
+	chr_count = strlen(str);
+	if ( chr_count > 31 ) chr_count = 31;
+
+	for(uint8_t i=0; i<chr_count; i++)
+	{
+		_desc_str[1+i] = str[i];
+	}
+	}
+
+	// first byte is length (including header), second byte is string type
+	_desc_str[0] = (TUSB_DESC_STRING << 8 ) | (2*chr_count + 2);
+
+	return _desc_str;
+}

--- a/firmware/src/boards/samd11_xplained/dfu.c
+++ b/firmware/src/boards/samd11_xplained/dfu.c
@@ -15,7 +15,7 @@
 /**
  * Handler for DFU_DETACH events, which should cause us to reboot into the bootloader.
  */
-void tud_dfu_rt_reboot_to_dfu(void)
+void tud_dfu_runtime_reboot_to_dfu_cb(void)
 {
 	// The easiest way to reboot into the bootloader is to trigger the watchdog timer.
 	// We'll just enable the WDT and then deliberately hang; which should cause an immediate reset.

--- a/firmware/src/boards/samd11_xplained/tusb_config.h
+++ b/firmware/src/boards/samd11_xplained/tusb_config.h
@@ -67,7 +67,7 @@
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC              1
-#define CFG_TUD_DFU_RT           1
+#define CFG_TUD_DFU_RUNTIME      1
 #define CFG_TUD_VENDOR           1
 
 // CDC FIFO size of TX and RX


### PR DESCRIPTION
This adds support for Apollo on https://www.adafruit.com/qtpy boards. I've been using it with an OrangeCrab 0.2.1

I've updated to latest tinyusb to support that board. There are some API changes related to DFU which I've updated, though haven't tested on any other boards.