### PR TITLE
modules: switch to tinyusb 0.14.0

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -79,13 +79,13 @@ include $(TINYUSB_PATH)/examples/rules.mk
 BUILD := _build
 
 # Flashing using Saturn-V.
-dfu: _build/$(BOARD)/$(BOARD)-firmware.bin
+dfu: _build/$(BOARD)/firmware.bin
 	dfu-util -a 0 -d 1d50:615c -D $< || dfu-util -a 0 -d 16d0:05a5 -D $<
 
 
 # Flashing using the Black Magic Probe,
 BMP_SERIAL ?= /dev/ttyACM0
-bmp: _build/$(BOARD)/$(BOARD)-firmware.elf
+bmp: _build/$(BOARD)/firmware.elf
 	arm-none-eabi-gdb -nx --batch \
 	-ex 'target extended-remote $(BMP_SERIAL)' \
 	-ex 'monitor swdp_scan' \

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -53,6 +53,7 @@ endif
 
 CFLAGS += \
 	-Wno-unused-parameter \
+	-Wno-cast-qual \
 	-fstrict-volatile-bitfields \
 	-D_BOARD_REVISION_MAJOR_=$(BOARD_REVISION_MAJOR) \
 	-D_BOARD_REVISION_MINOR_=$(BOARD_REVISION_MINOR) \

--- a/firmware/src/boards/luna_d11/dfu.c
+++ b/firmware/src/boards/luna_d11/dfu.c
@@ -15,7 +15,7 @@
 /**
  * Handler for DFU_DETACH events, which should cause us to reboot into the bootloader.
  */
-void tud_dfu_rt_reboot_to_dfu(void)
+void tud_dfu_runtime_reboot_to_dfu_cb(void)
 {
 	// The easiest way to reboot into the bootloader is to trigger the watchdog timer.
 	// We'll just enable the WDT and then deliberately hang; which should cause an immediate reset.

--- a/firmware/src/boards/luna_d11/tusb_config.h
+++ b/firmware/src/boards/luna_d11/tusb_config.h
@@ -67,7 +67,7 @@
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC              1
-#define CFG_TUD_DFU_RT           1
+#define CFG_TUD_DFU_RUNTIME      1
 #define CFG_TUD_VENDOR           1
 
 // CDC FIFO size of TX and RX

--- a/firmware/src/boards/luna_d21/dfu.c
+++ b/firmware/src/boards/luna_d21/dfu.c
@@ -15,7 +15,7 @@
 /**
  * Handler for DFU_DETACH events, which should cause us to reboot into the bootloader.
  */
-void tud_dfu_rt_reboot_to_dfu(void)
+void tud_dfu_runtime_reboot_to_dfu_cb(void)
 {
 	// The easiest way to reboot into the bootloader is to trigger the watchdog timer.
 	// We'll just enable the WDT and then deliberately hang; which should cause an immediate reset.

--- a/firmware/src/boards/luna_d21/tusb_config.h
+++ b/firmware/src/boards/luna_d21/tusb_config.h
@@ -67,7 +67,7 @@
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC              1
-#define CFG_TUD_DFU_RT           1
+#define CFG_TUD_DFU_RUNTIME      1
 #define CFG_TUD_VENDOR           1
 
 // CDC FIFO size of TX and RX

--- a/firmware/src/boards/samd11_xplained/dfu.c
+++ b/firmware/src/boards/samd11_xplained/dfu.c
@@ -15,7 +15,7 @@
 /**
  * Handler for DFU_DETACH events, which should cause us to reboot into the bootloader.
  */
-void tud_dfu_rt_reboot_to_dfu(void)
+void tud_dfu_runtime_reboot_to_dfu_cb(void)
 {
 	// The easiest way to reboot into the bootloader is to trigger the watchdog timer.
 	// We'll just enable the WDT and then deliberately hang; which should cause an immediate reset.

--- a/firmware/src/boards/samd11_xplained/tusb_config.h
+++ b/firmware/src/boards/samd11_xplained/tusb_config.h
@@ -67,7 +67,7 @@
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC              1
-#define CFG_TUD_DFU_RT           1
+#define CFG_TUD_DFU_RUNTIME      1
 #define CFG_TUD_VENDOR           1
 
 // CDC FIFO size of TX and RX


### PR DESCRIPTION
Switch to TinyUSB 0.14.0

updates lib/tinyusb submodule to 0.14.0 and adapts board source files accordingly
firmware for daisho couldn't be build to to missing bsp in TinyUSB

current TinyUSB submodule makes building for ESP32-S2 quite hard
