### PR TITLE
apollo_fpga: autoconvert between 12F and 25F bitstreams

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ license = "BSD"
 python = "^3.7"
 pyusb = "^1.1.1"
 pyvcd = "^0.2.4"
+yowasp_nextpnr_ecp5 = "*"
 
 [tool.poetry.dev-dependencies]
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ from setuptools import setup, find_packages
 install_requirements = [
     'pyusb',
     'pyvcd',
+    'yowasp-nextpnr-ecp5',
 ]
 
 # On ReadTheDocs don't enforce requirements; we'll use requirements.txt


### PR DESCRIPTION
Extend the host tools to automatically convert between LFE5U-25F and LFE5U-12F bitstreams if a part ID mismatch is detected. These two parts are compatible and their bitstreams are identical with the exception of the VERIFY_ID command.