### PR TITLE
Support static bitmasks as LED patterns

### DIFF
--- a/firmware/src/boards/cynthion_d11/led.c
+++ b/firmware/src/boards/cynthion_d11/led.c
@@ -26,16 +26,6 @@ static blink_pattern_t blink_pattern = BLINK_IDLE;
 
 
 /**
- * Sets the active LED blink pattern.
- */
-void led_set_blink_pattern(blink_pattern_t pattern)
-{
-    blink_pattern = pattern;
-    leds_off();
-}
-
-
-/**
  * Sets up each of the LEDs for use.
  */
 void led_init(void)
@@ -126,6 +116,24 @@ static void display_led_number(uint8_t number)
 
 
 /**
+ * Sets the active LED blink pattern.
+ */
+void led_set_blink_pattern(blink_pattern_t pattern)
+{
+    blink_pattern = pattern;
+    leds_off();
+    // Values of 0 to 31 should be set immediately as static patterns.
+    if (blink_pattern < 32) {
+      for (int i = 0; i < 5; i++) {
+        if (blink_pattern & (1 << i)) {
+          display_led_number(i);
+        }
+      }
+    }
+}
+
+
+/**
  * Task that handles blinking the heartbeat LED.
  */
 void heartbeat_task(void)
@@ -133,6 +141,11 @@ void heartbeat_task(void)
   static uint32_t start_ms = 0;
   static uint8_t active_led = 0;
   static bool count_up = true;
+
+  // Values of 0 to 31 define static patterns only.
+  if (blink_pattern < 32) {
+    return;
+  }
 
   // Blink every interval ms
   if ( board_millis() - start_ms < blink_pattern) return; // not enough time

--- a/firmware/src/boards/cynthion_d21/led.c
+++ b/firmware/src/boards/cynthion_d21/led.c
@@ -26,16 +26,6 @@ static blink_pattern_t blink_pattern = BLINK_IDLE;
 
 
 /**
- * Sets the active LED blink pattern.
- */
-void led_set_blink_pattern(blink_pattern_t pattern)
-{
-	blink_pattern = pattern;
-	leds_off();
-}
-
-
-/**
  * Sets up each of the LEDs for use.
  */
 void led_init(void)
@@ -113,6 +103,24 @@ static void display_led_number(uint8_t number)
 
 
 /**
+ * Sets the active LED blink pattern.
+ */
+void led_set_blink_pattern(blink_pattern_t pattern)
+{
+    blink_pattern = pattern;
+    leds_off();
+    // Values of 0 to 31 should be set immediately as static patterns.
+    if (blink_pattern < 32) {
+      for (int i = 0; i < 5; i++) {
+        if (blink_pattern & (1 << i)) {
+          display_led_number(i);
+        }
+      }
+    }
+}
+
+
+/**
  * Task that handles blinking the heartbeat LED.
  */
 void heartbeat_task(void)
@@ -120,6 +128,11 @@ void heartbeat_task(void)
   static uint32_t start_ms = 0;
   static uint8_t active_led = 0;
   static bool count_up = true;
+
+  // Values of 0 to 31 define static patterns only.
+  if (blink_pattern < 32) {
+    return;
+  }
 
   // Blink every interval ms
   if ( board_millis() - start_ms < blink_pattern) return; // not enough time

--- a/firmware/src/led.h
+++ b/firmware/src/led.h
@@ -13,7 +13,13 @@
 #include <apollo_board.h>
 
 /**
- * Different blink patterns with different semantic meanings.
+ * LED patterns.
+ *
+ * Values 0 to 31 will be interpreted as static bitmasks, and can be used
+ * to turn on specific combinations of LEDs in a fixed pattern.
+ *
+ * Other values as defined in this enum will produce dynamic blink patterns,
+ * with different semantic meanings.
  */
 typedef enum {
   BLINK_IDLE = 500,
@@ -27,6 +33,8 @@ typedef enum {
 
 /**
  * Sets the active LED blink pattern.
+ *
+ * See @ref blink_pattern_t for the meaning of the pattern argument.
  */
 void led_set_blink_pattern(blink_pattern_t pattern);
 


### PR DESCRIPTION
This PR allows static bitmasks to be applied to the LEDs, as well as dynamic blink patterns.

Conveniently, none of the existing blink patterns have enum values of less than the maximum bitmask.

Required for Cynthion factory test.