### PR TITLE
apollo_fpga: Flash programming speed improvements

### DIFF
--- a/apollo_fpga/ecp5.py
+++ b/apollo_fpga/ecp5.py
@@ -618,7 +618,7 @@ class ECP5CommandBasedProgrammer(ECP5Programmer):
         self._flash_wait_for_completion()
 
 
-    def _flash_erase_size(self, address, size):
+    def _flash_erase(self, address, size):
         """ Erases from the defined address and size with sector / block operations.
 
         Both arguments are rounded to multiples of 4K (min. granularity).
@@ -691,7 +691,7 @@ class ECP5CommandBasedProgrammer(ECP5Programmer):
 
         # Prepare for writing by erasing the chip.
         if erase_first:
-            self._flash_erase_size(0, len(bitstream))
+            self._flash_erase(0, len(bitstream))
 
         #
         # Finally, program the bitstream itself.

--- a/apollo_fpga/ecp5.py
+++ b/apollo_fpga/ecp5.py
@@ -577,8 +577,6 @@ class ECP5CommandBasedProgrammer(ECP5Programmer):
         """ Blocks until the flash has compelted any pending operations. """
 
         while True:
-            time.sleep(1e-6)
-
             # Read the flash's status register...
             flash_status = self._background_spi_transfer([self.FlashOpcode.READ_STATUS1, 0])
 
@@ -586,6 +584,7 @@ class ECP5CommandBasedProgrammer(ECP5Programmer):
             if (flash_status[1] & self.SPI_FLASH_BUSY_MASK) == 0:
                 break
 
+            time.sleep(1e-6)
 
     def _get_flash_status(self):
         """ Retrieves the FPGA's configuration flash's status register. """

--- a/apollo_fpga/jtag.py
+++ b/apollo_fpga/jtag.py
@@ -385,11 +385,6 @@ class JTAGChain:
         state_number = self.STATE_NUMBERS[state]
         self.debugger.out_request(REQUEST_JTAG_GO_TO_STATE, value=state_number)
 
-        # TODO: remove this; this if for debugging only
-        current_state_raw = self.debugger.in_request(REQUEST_JTAG_GET_STATE, length=1)
-        current_state_number = int.from_bytes(current_state_raw, byteorder='little')
-        assert(current_state_number == state_number)
-
 
     def move_to_state(self, state_name):
         """ Moves the JTAG scan chain to the relevant state.


### PR DESCRIPTION
Improves flashing speed by:
- Ignoring unused SPI responses.
- Avoiding an unnecessary check.
- Performing partial erases when programming.

#9 implements partial erases too, but the version in this PR is also able to use mixed eraseblock sizes.

Offset writes and reads are intentionally left out of this PR, but it's open for discussion.
