### PR TITLE
pyproject.toml: fix installation issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,9 @@ dependencies = [
 [project.urls]
 repository = "https://github.com/greatscottgadgets/apollo"
 
-[tool.setuptools]
-packages = ["apollo_fpga"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["apollo_fpga*"]
 
 [project.scripts]
 apollo = "apollo_fpga.commands.cli:main"


### PR DESCRIPTION
Submodules (`protocol`, `support`, `commands`, `gateware`) were not installed in certain scenarios.