### PR TITLE
firmware: Disallow FPGA takeover of USB port

### DIFF
--- a/firmware/src/boards/cynthion_d11/fpga.c
+++ b/firmware/src/boards/cynthion_d11/fpga.c
@@ -71,5 +71,5 @@ void trigger_fpga_reconfiguration(void)
 	gpio_set_pin_direction(FPGA_PROGRAM, GPIO_DIRECTION_IN);
 
 	// Update internal state.
-	fpga_online = true;
+	fpga_set_online(true);
 }

--- a/firmware/src/boards/cynthion_d11/fpga_adv.c
+++ b/firmware/src/boards/cynthion_d11/fpga_adv.c
@@ -24,8 +24,8 @@
 #define TIMEOUT 100UL
 static uint32_t last_phy_adv = 0;
 
-// Allow deferred switching of the USB port.
-static bool defer_hand_off = false;
+// Switching the shared USB port to the FPGA is allowed.
+static bool fpga_usb_allowed = false;
 
 // Create a reference to our SERCOM object.
 typedef Sercom sercom_t;
@@ -114,9 +114,8 @@ void fpga_adv_task(void)
     // Take over USB after timeout
 	if (fpga_requesting_port() == false) {
 		take_over_usb();
-	} else if (defer_hand_off) {
+	} else if (fpga_usb_allowed) {
 		hand_off_usb();
-		defer_hand_off = false;
 	}
 #endif
 }
@@ -124,15 +123,9 @@ void fpga_adv_task(void)
 /**
  * Allow FPGA takeover of the USB port
  */
-void allow_fpga_takeover_usb(void)
+void allow_fpga_takeover_usb(bool allow)
 {
-#ifdef BOARD_HAS_USB_SWITCH
-	if (fpga_requesting_port()) {
-		hand_off_usb();
-	} else {
-		defer_hand_off = true;
-	}
-#endif
+	fpga_usb_allowed = allow;
 }
 
 /**

--- a/firmware/src/boards/cynthion_d21/fpga.c
+++ b/firmware/src/boards/cynthion_d21/fpga.c
@@ -76,5 +76,5 @@ void trigger_fpga_reconfiguration(void)
 	gpio_set_pin_direction(PIN_PROG, GPIO_DIRECTION_IN);
 
 	// Update internal state.
-	fpga_online = true;
+	fpga_set_online(true);
 }

--- a/firmware/src/boards/cynthion_d21/fpga_adv.c
+++ b/firmware/src/boards/cynthion_d21/fpga_adv.c
@@ -25,7 +25,7 @@ void fpga_adv_task(void)
 /**
  * Allow FPGA takeover of the USB port
  */
-void allow_fpga_takeover_usb(void)
+void allow_fpga_takeover_usb(bool allow)
 {
 }
 

--- a/firmware/src/boards/daisho/fpga_adv.c
+++ b/firmware/src/boards/daisho/fpga_adv.c
@@ -25,7 +25,7 @@ void fpga_adv_task(void)
 /**
  * Allow FPGA takeover of the USB port
  */
-void allow_fpga_takeover_usb(void)
+void allow_fpga_takeover_usb(bool allow)
 {
 }
 

--- a/firmware/src/boards/qtpy/fpga.c
+++ b/firmware/src/boards/qtpy/fpga.c
@@ -83,5 +83,5 @@ void trigger_fpga_reconfiguration(void)
 	gpio_set_pin_direction(PIN_PROG, GPIO_DIRECTION_IN);
 
 	// Update internal state.
-	fpga_online = true;
+	fpga_set_online(true);
 }

--- a/firmware/src/boards/qtpy/fpga_adv.c
+++ b/firmware/src/boards/qtpy/fpga_adv.c
@@ -25,7 +25,7 @@ void fpga_adv_task(void)
 /**
  * Allow FPGA takeover of the USB port
  */
-void allow_fpga_takeover_usb(void)
+void allow_fpga_takeover_usb(bool allow)
 {
 }
 

--- a/firmware/src/boards/samd11_xplained/fpga.c
+++ b/firmware/src/boards/samd11_xplained/fpga.c
@@ -76,5 +76,5 @@ void trigger_fpga_reconfiguration(void)
 	gpio_set_pin_direction(PIN_PROG, GPIO_DIRECTION_IN);
 
 	// Update internal state.
-	fpga_online = true;
+	fpga_set_online(true);
 }

--- a/firmware/src/boards/samd11_xplained/fpga_adv.c
+++ b/firmware/src/boards/samd11_xplained/fpga_adv.c
@@ -25,7 +25,7 @@ void fpga_adv_task(void)
 /**
  * Allow FPGA takeover of the USB port
  */
-void allow_fpga_takeover_usb(void)
+void allow_fpga_takeover_usb(bool allow)
 {
 }
 

--- a/firmware/src/fpga.c
+++ b/firmware/src/fpga.c
@@ -8,6 +8,8 @@
 #include <bsp/board_api.h>
 
 #include "jtag.h"
+#include "fpga.h"
+#include "fpga_adv.h"
 
 
 extern uint8_t jtag_out_buffer[256];
@@ -39,7 +41,7 @@ void force_fpga_offline(void)
 	jtag_deinit();
 
 	// Update internal state.
-	fpga_online = false;
+	fpga_set_online(false);
 }
 
 /*
@@ -48,4 +50,22 @@ void force_fpga_offline(void)
 bool fpga_is_online(void)
 {
 	return fpga_online;
+}
+
+/**
+ * Update our understanding of the FPGA's state.
+ */
+void fpga_set_online(bool online)
+{
+	fpga_online = online;
+
+	/*
+	 * When the FPGA goes offline, stop allowing the FPGA to take over the
+	 * shared USB port. After the FPGA comes back online, the host may
+	 * request that it be allowed again, but we assume that it is
+	 * disallowed until told otherwise.
+	 */
+	if (!online) {
+		allow_fpga_takeover_usb(false);
+	}
 }

--- a/firmware/src/fpga.h
+++ b/firmware/src/fpga.h
@@ -39,4 +39,9 @@ void force_fpga_offline(void);
  */
 bool fpga_is_online(void);
 
+/**
+ * Update our understanding of the FPGA's state.
+ */
+void fpga_set_online(bool online);
+
 #endif

--- a/firmware/src/fpga_adv.h
+++ b/firmware/src/fpga_adv.h
@@ -23,7 +23,7 @@ void fpga_adv_task(void);
 /**
  * Allow FPGA takeover of the USB port
  */
-void allow_fpga_takeover_usb(void);
+void allow_fpga_takeover_usb(bool allow);
 
 /**
  * True if we received an advertisement message within the last time window.

--- a/firmware/src/jtag.c
+++ b/firmware/src/jtag.c
@@ -116,10 +116,10 @@ bool handle_jtag_request_set_out_buffer(uint8_t rhport, tusb_control_request_t c
 	// HACK: check the buffer for commands that affect the FPGA configuration state.
     if (request->wLength == 1) {
 		if (jtag_out_buffer[0] == ISC_ENABLE) {
-			fpga_online = false;
+			fpga_set_online(false);
 		}
 		if (jtag_out_buffer[0] == ISC_DISABLE) {
-			fpga_online = true;
+			fpga_set_online(true);
 		}
     }
 

--- a/firmware/src/vendor.c
+++ b/firmware/src/vendor.c
@@ -151,7 +151,7 @@ bool handle_allow_fpga_takeover_usb(uint8_t rhport, tusb_control_request_t const
 
 bool handle_allow_fpga_takeover_usb_finish(uint8_t rhport, tusb_control_request_t const* request)
 {
-	allow_fpga_takeover_usb();
+	allow_fpga_takeover_usb(true);
 	return true;
 }
 


### PR DESCRIPTION
Whenever the FPGA is taken offline, stop allowing it to take over the shared USB port. This prevents a later FPGA configuration from taking over the port before it is explicitly allowed to do so.

This fixes a bug introduced in #50 in which a port handoff could be inappropriately deferred from one FPGA configuration (which does not request the port) to a later configuration (which does request the port):

```
$ blinky.py
$ bulk_speed_test.py (modified to use CONTROL)
INFO    | __init__    | Building and uploading gateware to attached Cynthion r1.3...
Traceback (most recent call last):
  File "/home/mossmann/src/apollo/apollo_fpga/ecp5.py", line 467, in configure
    status = self._read_status()
             ^^^^^^^^^^^^^^^^^^^
  File "/home/mossmann/src/apollo/apollo_fpga/ecp5.py", line 515, in _read_status
    status_bytes = self._execute_command(self.Opcode.LSC_READ_STATUS, self.STATUS_REGISTER_LENGTH,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mossmann/src/apollo/apollo_fpga/ecp5.py", line 988, in _execute_command
    response = self.chain.shift_data(tdi=data, length=length, state_after='DRPAUSE')
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mossmann/src/apollo/apollo_fpga/jtag.py", line 479, in shift_data
    response = self._shift_while_in_state('DRSHIFT', tdi=tdi, length=length, ignore_response=ignore_response,
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mossmann/src/apollo/apollo_fpga/jtag.py", line 422, in _shift_while_in_state
    self._ensure_in_state(state)
  File "/home/mossmann/src/apollo/apollo_fpga/jtag.py", line 386, in _ensure_in_state
    self.debugger.out_request(REQUEST_JTAG_GO_TO_STATE, value=state_number)
  File "/home/mossmann/src/apollo/apollo_fpga/__init__.py", line 272, in out_request
    return self.device.ctrl_transfer(request_type, number, value, index, data, timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mossmann/src/cynthion/cynthion/python/venv/lib/python3.11/site-packages/usb/core.py", line 1082, in ctrl_transfer
    ret = self._ctx.backend.ctrl_transfer(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mossmann/src/cynthion/cynthion/python/venv/lib/python3.11/site-packages/usb/backend/libusb1.py", line 893, in ctrl_transfer
    ret = _check(self.lib.libusb_control_transfer(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mossmann/src/cynthion/cynthion/python/venv/lib/python3.11/site-packages/usb/backend/libusb1.py", line 604, in _check
    raise USBError(_strerror(ret), ret, _libusb_errno[ret])
usb.core.USBError: [Errno 32] Pipe error

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/mossmann/src/cynthion/cynthion/python/venv/lib/python3.11/site-packages/cynthion/gateware/platform/core.py", line 79, in toolchain_program
    programmer.configure(bitstream)
  File "/home/mossmann/src/apollo/apollo_fpga/ecp5.py", line 472, in configure
    self.chain.debugger.set_led_pattern(self.chain.debugger.LED_PATTERN_IDLE)
  File "/home/mossmann/src/apollo/apollo_fpga/__init__.py", line 285, in set_led_pattern
    self.out_request(self.REQUEST_SET_LED_PATTERN, number)
  File "/home/mossmann/src/apollo/apollo_fpga/__init__.py", line 272, in out_request
    return self.device.ctrl_transfer(request_type, number, value, index, data, timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mossmann/src/cynthion/cynthion/python/venv/lib/python3.11/site-packages/usb/core.py", line 1082, in ctrl_transfer
    ret = self._ctx.backend.ctrl_transfer(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mossmann/src/cynthion/cynthion/python/venv/lib/python3.11/site-packages/usb/backend/libusb1.py", line 893, in ctrl_transfer
    ret = _check(self.lib.libusb_control_transfer(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mossmann/src/cynthion/cynthion/python/venv/lib/python3.11/site-packages/usb/backend/libusb1.py", line 604, in _check
    raise USBError(_strerror(ret), ret, _libusb_errno[ret])
usb.core.USBError: [Errno 32] Pipe error      

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/mossmann/src/luna/bulk_speed_test.py", line 166, in <module>
    device = top_level_cli(SpeedTestDevice,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mossmann/src/luna/luna/__init__.py", line 113, in top_level_cli
    products = platform.build(fragment,
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mossmann/src/cynthion/cynthion/python/venv/lib/python3.11/site-packages/amaranth/build/plat.py", line 113, in build
    self.toolchain_program(products, name, **(program_opts or {}))
  File "/home/mossmann/src/cynthion/cynthion/python/venv/lib/python3.11/site-packages/cynthion/gateware/platform/core.py", line 77, in toolchain_program
    with debugger.jtag as jtag:
  File "/home/mossmann/src/apollo/apollo_fpga/jtag.py", line 216, in __exit__
    self.debugger.out_request(REQUEST_JTAG_STOP)
  File "/home/mossmann/src/apollo/apollo_fpga/__init__.py", line 272, in out_request
    return self.device.ctrl_transfer(request_type, number, value, index, data, timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mossmann/src/cynthion/cynthion/python/venv/lib/python3.11/site-packages/usb/core.py", line 1082, in ctrl_transfer
    ret = self._ctx.backend.ctrl_transfer(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mossmann/src/cynthion/cynthion/python/venv/lib/python3.11/site-packages/usb/backend/libusb1.py", line 893, in ctrl_transfer
    ret = _check(self.lib.libusb_control_transfer(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mossmann/src/cynthion/cynthion/python/venv/lib/python3.11/site-packages/usb/backend/libusb1.py", line 604, in _check
    raise USBError(_strerror(ret), ret, _libusb_errno[ret])
usb.core.USBError: [Errno 32] Pipe error
```