### PR TITLE
apollo_fpga: fix handing off USB port to Apollo under Windows

### DIFF
--- a/apollo_fpga/__init__.py
+++ b/apollo_fpga/__init__.py
@@ -7,6 +7,7 @@
 import os
 import time
 import usb.core
+import platform
 
 from .jtag  import JTAGChain
 from .spi   import DebugSPIConnection
@@ -128,6 +129,10 @@ class ApolloDebugger:
         stub_if = cls._device_has_stub_iface(device, return_iface=True)
         if stub_if is None:
             raise DebuggerNotFound("No Apollo stub interface found")
+
+        # In Windows, we first need to claim the target interface.
+        if platform.system() == "Windows":
+            usb.util.claim_interface(device, stub_if)
 
         # Send the request
         intf_number = stub_if.bInterfaceNumber


### PR DESCRIPTION
Under Windows, libusb sends the vendor request with the recipient set to interface 0 by default. Claiming the appropiate interface before seems to work.