### PR TITLE
Hold Sideband PHY RESET low on older Cynthions

### DIFF
--- a/firmware/src/boards/cynthion_d11/apollo_board.h
+++ b/firmware/src/boards/cynthion_d11/apollo_board.h
@@ -1,7 +1,7 @@
 /**
  * Apollo board definitions for Cynthion r0.3 and above
  *
- * Copyright (c) 2020-2023 Great Scott Gadgets <info@greatscottgadgets.com>
+ * Copyright (c) 2020-2024 Great Scott Gadgets <info@greatscottgadgets.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -12,16 +12,13 @@
 #include <hal/include/hal_gpio.h>
 #include <stdbool.h>
 
-#if (((_BOARD_REVISION_MAJOR_ == 0) && (_BOARD_REVISION_MINOR_ >= 6)) || (_BOARD_REVISION_MAJOR_ == 1))
-#define BOARD_HAS_USB_SWITCH
-/*
- * Hardware revisions r0.3 through r0.5 have a button, but its GPIO pin is
- * shared with LED_A.  We never needed to use the button on those revisions
- * because they effectively had a dedicated USB port for Apollo.  Sharing the
- * pin is tricky, but we'll probably never need to implement that.  Unless and
- * until we implement it, pretend that the button does not exist.
- */
 #define BOARD_HAS_PROGRAM_BUTTON
+#define BOARD_HAS_SHARED_USB
+
+#if ((_BOARD_REVISION_MAJOR_ == 0) && (_BOARD_REVISION_MINOR_ < 6))
+#define BOARD_HAS_SHARED_BUTTON
+#else
+#define BOARD_HAS_USB_SWITCH
 #endif
 
 /**

--- a/firmware/src/boards/cynthion_d11/fpga_adv.c
+++ b/firmware/src/boards/cynthion_d11/fpga_adv.c
@@ -3,7 +3,7 @@
  *
  * This file is part of Apollo.
  *
- * Copyright (c) 2023 Great Scott Gadgets <info@greatscottgadgets.com>
+ * Copyright (c) 2023-2024 Great Scott Gadgets <info@greatscottgadgets.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -30,6 +30,7 @@ static bool fpga_usb_allowed = false;
 // Create a reference to our SERCOM object.
 typedef Sercom sercom_t;
 static sercom_t *sercom = SERCOM1;
+
 
 static void fpga_adv_byte_received_cb(uint8_t byte, int parity_error);
 
@@ -125,7 +126,16 @@ void fpga_adv_task(void)
  */
 void allow_fpga_takeover_usb(bool allow)
 {
+#ifdef BOARD_HAS_USB_SWITCH
 	fpga_usb_allowed = allow;
+#else
+	/*
+	 * Boards without a USB switch also lack the advertising channel used
+	 * by the FPGA to request the USB port. On those platforms we
+	 * immediately hand off the port to the FPGA.
+	 */
+	hand_off_usb();
+#endif
 }
 
 /**

--- a/firmware/src/boards/cynthion_d11/led.c
+++ b/firmware/src/boards/cynthion_d11/led.c
@@ -3,7 +3,7 @@
  *
  * This file is part of LUNA.
  *
- * Copyright (c) 2020 Great Scott Gadgets <info@greatscottgadgets.com>
+ * Copyright (c) 2020-2024 Great Scott Gadgets <info@greatscottgadgets.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -152,10 +152,10 @@ void led_task(void)
 
   // When the device is idle, use the following scheme for LEDs:
   // - LED A: power indication (always on in Apollo)
-  // - LED B: FPGA allowed online (indicates PROGRAM toggle)
+  // - LED B: FPGA allowed online
   // - LED C: FPGA has requested CONTROL port
   // - LED D: USB switched to FPGA
-  // - LED E: flashing patterns (e.g. fault indication)
+  // - LED E: reserved for flashing patterns (e.g. fault indication)
   if (led_pattern == LED_IDLE) {
     led_set(LED_A, true);
     led_set(LED_B, fpga_is_online());

--- a/firmware/src/boards/cynthion_d21/apollo_board.h
+++ b/firmware/src/boards/cynthion_d21/apollo_board.h
@@ -3,7 +3,7 @@
  *
  * This file is part of LUNA.
  *
- * Copyright (c) 2020 Great Scott Gadgets <info@greatscottgadgets.com>
+ * Copyright (c) 2020-2024 Great Scott Gadgets <info@greatscottgadgets.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -14,6 +14,7 @@
 #include <hal/include/hal_gpio.h>
 #include <stdbool.h>
 
+//#define BOARD_HAS_SHARED_USB
 
 // Indicate that this board features a configuration flash.
 #define _BOARD_HAS_CONFIG_FLASH_

--- a/firmware/src/boards/cynthion_d21/jtag.c
+++ b/firmware/src/boards/cynthion_d21/jtag.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2023 Great Scott Gadgets <info@greatscottgadgets.com>
+ * Copyright (c) 2020-2024 Great Scott Gadgets <info@greatscottgadgets.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/firmware/src/button.c
+++ b/firmware/src/button.c
@@ -1,7 +1,7 @@
 /**
  * button handler
  *
- * Copyright (c) 2023 Great Scott Gadgets <info@greatscottgadgets.com>
+ * Copyright (c) 2023-2024 Great Scott Gadgets <info@greatscottgadgets.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -11,6 +11,12 @@
 #include "apollo_board.h"
 #include <hal/include/hal_gpio.h>
 
+static inline void delay(int cycles)
+{
+        while (cycles-- != 0)
+                __NOP();
+}
+
 
 /**
  * Detect button press.
@@ -18,7 +24,20 @@
 bool button_pressed(void)
 {
 #ifdef BOARD_HAS_PROGRAM_BUTTON
+
+#ifdef BOARD_HAS_SHARED_BUTTON
+	bool level = gpio_get_pin_level(PROGRAM_BUTTON);
+	gpio_set_pin_direction(PROGRAM_BUTTON, GPIO_DIRECTION_IN);
+	gpio_set_pin_pull_mode(PROGRAM_BUTTON, GPIO_PULL_UP);
+	delay(50);
+	bool pressed = (gpio_get_pin_level(PROGRAM_BUTTON) == false);
+	gpio_set_pin_direction(PROGRAM_BUTTON, GPIO_DIRECTION_OUT);
+	gpio_set_pin_level(PROGRAM_BUTTON, level);
+	return pressed;
+#else
 	return (gpio_get_pin_level(PROGRAM_BUTTON) == false);
+#endif
+
 #else
 	return false;
 #endif


### PR DESCRIPTION
Also support the button on older Cynthions (r0.3-r0.5). The button is referred to as PROGRAM in the source code to match newer Cynthions but is labeled DFU on silkscreen.

This fixes #21 for board revisions r0.3-r0.4 but does not fix r0.1-r0.2. In theory this type of solution could work for r0.1-r0.2, but my initial tests were not successful. For now, Sideband PHY usage is unsupported on r0.1-r0.2.

See also the similar fix for Saturn-V: https://github.com/greatscottgadgets/saturn-v/issues/15