### PR TITLE
firmware.fpga_adv: replace UART reception with edge counter

### DIFF
--- a/firmware/src/fpga_adv.h
+++ b/firmware/src/fpga_adv.h
@@ -11,7 +11,7 @@
 #define __FPGA_ADV_H__
 
 /**
- * Initialize FPGA_ADV receive-only serial port
+ * Initialize FPGA_ADV receive-only pin
  */
 void fpga_adv_init(void);
 


### PR DESCRIPTION
Because there is no crystal for the microcontroller on Cynthion, UART baud rate mismatch can result in a failure to receive FPGA advertisements. We only need one type of advertisement, so we're replacing the UART receiver with simpler pulse detection. We require a minimum number of pulses per measurement period in order to ignore glitches that occur during FPGA configuration.