### PR TITLE
Correct Base32 representation of serial number

### DIFF
--- a/firmware/src/mcu/samd11/usb_descriptors.c
+++ b/firmware/src/mcu/samd11/usb_descriptors.c
@@ -161,7 +161,7 @@ static uint16_t *get_serial_number_string_descriptor(void)
 		}
 		bits_left -= 5;
 		int index = (buffer >> bits_left) & 0x1f;
-		_desc_str[count++] = index + (index < 26 ? 'A' : '2');  // RFC 4648 Base32
+		_desc_str[count++] = index + (index < 26 ? 'A' : '2' - 26);  // RFC 4648 Base32
 	}
 
 	return _desc_str;

--- a/firmware/src/vendor.c
+++ b/firmware/src/vendor.c
@@ -23,7 +23,7 @@
 #include "fpga_adv.h"
 
 #define USB_API_MAJOR 1
-#define USB_API_MINOR 0
+#define USB_API_MINOR 1
 
 
 // Supported vendor requests.


### PR DESCRIPTION
Bump USB API to 1.1
Fix #69