### PR TITLE
firmware: add board_rev.c to Pico build

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(${PROJECT} PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/src/boards/${BOARD}/uart.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/mcu/rp2040/dfu.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/mcu/rp2040/usb_descriptors.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/board_rev.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/button.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/console.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/debug_spi.c


### PR DESCRIPTION
The Pico build broke after merging #34 because #32 had been merged since the last rebase of #34.