### PR TITLE
firmware: select string descriptors at run time

### DIFF
--- a/firmware/src/board_rev.c
+++ b/firmware/src/board_rev.c
@@ -23,3 +23,19 @@ __attribute__((weak)) uint16_t get_board_revision(void)
 {
     return (_BOARD_REVISION_MAJOR_ << 8) | _BOARD_REVISION_MINOR_;
 }
+
+/**
+ * Return the manufacturer string.
+ */
+__attribute__((weak)) const char *get_manufacturer_string(void)
+{
+	return "Apollo Project";
+}
+
+/**
+ * Return the product string.
+ */
+__attribute__((weak)) const char *get_product_string(void)
+{
+	return "Apollo Debugger";
+}

--- a/firmware/src/board_rev.h
+++ b/firmware/src/board_rev.h
@@ -22,5 +22,14 @@ void detect_hardware_revision(void);
  */
 uint16_t get_board_revision(void);
 
+/**
+ * Return the manufacturer string.
+ */
+const char *get_manufacturer_string(void);
+
+/**
+ * Return the product string.
+ */
+const char *get_product_string(void);
 
 #endif

--- a/firmware/src/boards/cynthion_d11/board_rev.c
+++ b/firmware/src/boards/cynthion_d11/board_rev.c
@@ -105,4 +105,20 @@ uint16_t get_board_revision(void)
     return revision;
 }
 
+/**
+ * Return the manufacturer string.
+ */
+const char *get_manufacturer_string(void)
+{
+        return (gsg_production) ? "Great Scott Gadgets" : "Apollo Project";
+}
+
+/**
+ * Return the product string.
+ */
+const char *get_product_string(void)
+{
+        return (gsg_production) ? "Cynthion Apollo Debugger" : "Apollo Debugger";
+}
+
 #endif

--- a/firmware/src/mcu/samd11/usb_descriptors.c
+++ b/firmware/src/mcu/samd11/usb_descriptors.c
@@ -28,6 +28,8 @@
 #include "tusb.h"
 #include "board_rev.h"
 
+#define MANUFACTURER_STRING_INDEX  1
+#define PRODUCT_STRING_INDEX       2
 #define SERIAL_NUMBER_STRING_INDEX 3
 
 //--------------------------------------------------------------------+
@@ -113,8 +115,8 @@ uint8_t const * tud_descriptor_configuration_cb(uint8_t index)
 char const* string_desc_arr [] =
 {
 	(const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
-	"Great Scott Gadgets",         // 1: Manufacturer
-	"Apollo Debugger",             // 2: Product
+	NULL,                          // 1: Manufacturer
+	NULL,                          // 2: Product
 	NULL,                          // 3: Serials, should use chip ID
 };
 
@@ -191,12 +193,12 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid)
 		if (index == 0xee) {
 			// Microsoft OS 1.0 String Descriptor
 			str = "MSFT100\xee";
+		} else if (index == MANUFACTURER_STRING_INDEX) {
+			str = get_manufacturer_string();
+		} else if (index == PRODUCT_STRING_INDEX) {
+			str = get_product_string();
 		} else {
-			if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) {
-				return NULL;
-			}
-
-			str = string_desc_arr[index];
+			return NULL;
 		}
 
 		// Cap at max char


### PR DESCRIPTION
Cynthion now identifies itself on USB with the trademarks "Cynthion" and "Great Scott Gadgets" only if it is detected to have been manufactured by Great Scott Gadgets at run time. This also cleans up string descriptor handling for Cynthion and other SAMD11/SAMD21 platforms. It does not update other platforms which I think require discussion before changing.