### PR TITLE
Update pyproject for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,14 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=64", "setuptools-git-versioning<2"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "apollo-fpga"
-version = "0.0.5"
 authors = [
     {name = "Great Scott Gadgets", email = "dev@greatscottgadgets.com"}
 ]
 license = { text = "BSD" }
-description = "host tools for Apollo FPGA debug controllers"
+description = "Python library and host tools for Apollo FPGA debug controllers."
 readme = "README.md"
 requires-python = ">=3.8"
 classifiers = [
@@ -23,7 +22,6 @@ classifiers = [
     'License :: OSI Approved :: BSD License',
     'Operating System :: OS Independent',
     'Topic :: Scientific/Engineering',
-    'Topic :: Security',
 ]
 dependencies = [
     "pyusb>1.1.1",
@@ -31,15 +29,17 @@ dependencies = [
     "prompt-toolkit>3.0.16",
     "pyxdg>=0.27",
 ]
+dynamic = ["version"]
 
 [project.optional-dependencies]
 py_ci = [
     "amaranth==0.4.1",
-    "luna-usb @ git+https://github.com/greatscottgadgets/luna@main"
+    "luna-usb~=0.1",
 ]
 
 [project.urls]
 repository = "https://github.com/greatscottgadgets/apollo"
+issues     = "https://github.com/greatscottgadgets/apollo/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -50,3 +50,7 @@ apollo = "apollo_fpga.commands.cli:main"
 
 [tool.pdm.scripts]
 test.cmd = "python -m unittest discover -p jtag_svf.py -v"
+
+[tool.setuptools-git-versioning]
+enabled = true
+starting_version = "1.0.0"


### PR DESCRIPTION
This PR:

1. Adds support for the `setuptools-git-versioning` plugin that uses repository tags to automatically manage package release versions.
2. Updates the package description.
3. Removes `Topic :: Security` from the package metadata.
4. Adds `issues` to the Project URL's
5. Replaces `luna-usb` git dependency with a release version.