### PR TITLE
Use pid.codes test VID/PID for non-Cynthion boards

### DIFF
--- a/apollo_fpga/__init__.py
+++ b/apollo_fpga/__init__.py
@@ -37,12 +37,16 @@ class ApolloDebugger:
     """ Class representing a link to an Apollo Debug Module. """
 
     # VID/PID pairs for Apollo and gateware.
-    APOLLO_USB_IDS = [(0x1d50, 0x615c)]
+    APOLLO_USB_IDS = [(0x1d50, 0x615c), (0x1209, 0x0010)]
     LUNA_USB_IDS   = [(0x1d50, 0x615b)]
 
-    # Add pid.codes VID/PID pairs with PID from 0x0001 to 0x0010
-    for i in range(16):
+    # Add pid.codes test VID/PID pairs with PID from 0x0001 to 0x0005 used in
+    # LUNA example gateware.
+    for i in range(5):
         LUNA_USB_IDS += [(0x1209, i+1)]
+
+    # Add pid.codes test VID/PID used by flash bridge.
+    LUNA_USB_IDS += [(0x1209, 0x000f)]
 
     # If we have a LUNA_USB_IDS variable, we can use it to find the LUNA device.
     if os.getenv("LUNA_USB_IDS"):

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -95,7 +95,7 @@ BUILD := _build
 
 # Flashing using Saturn-V.
 dfu: _build/$(BOARD)/firmware.bin
-	dfu-util -a 0 -d 1d50:615c -D $< || dfu-util -a 0 -d 16d0:05a5 -D $<
+	dfu-util -a 0 -d 1d50:615c -D $< || dfu-util -a 0 -d 1209:0010 -D $<
 
 
 # Flashing using the Black Magic Probe,

--- a/firmware/src/boards/cynthion_d11/apollo_board.h
+++ b/firmware/src/boards/cynthion_d11/apollo_board.h
@@ -12,6 +12,9 @@
 #include <hal/include/hal_gpio.h>
 #include <stdbool.h>
 
+#define USB_VID 0x1d50
+#define USB_PID 0x615c
+
 #define BOARD_HAS_PROGRAM_BUTTON
 #define BOARD_HAS_SHARED_USB
 

--- a/firmware/src/boards/cynthion_d21/apollo_board.h
+++ b/firmware/src/boards/cynthion_d21/apollo_board.h
@@ -14,6 +14,9 @@
 #include <hal/include/hal_gpio.h>
 #include <stdbool.h>
 
+#define USB_VID 0x1d50
+#define USB_PID 0x615c
+
 //#define BOARD_HAS_SHARED_USB
 
 // Indicate that this board features a configuration flash.

--- a/firmware/src/boards/daisho/apollo_board.h
+++ b/firmware/src/boards/daisho/apollo_board.h
@@ -10,6 +10,10 @@
 #ifndef __APOLLO_BOARD_H__
 #define __APOLLO_BOARD_H__
 
+/* pid.codes test VID/PID */
+#define USB_VID 0x1209
+#define USB_PID 0x0010
+
 #define _BOARD_HAS_DEBUG_SPI
 
 #include <chip.h>

--- a/firmware/src/boards/daisho/usb_descriptors.c
+++ b/firmware/src/boards/daisho/usb_descriptors.c
@@ -26,6 +26,7 @@
  */
 
 #include "tusb.h"
+#include "apollo_board.h"
 
 #define SERIAL_NUMBER_STRING_INDEX 3
 
@@ -44,10 +45,8 @@ tusb_desc_device_t const desc_device =
 
 	.bMaxPacketSize0    = CFG_TUD_ENDPOINT0_SIZE,
 
-	// These are a unique VID/PID for Apollo on Daisho.
-	// TODO: should we replace these with an OpenMoko VID/PID pair, to match other GSG products?
-	.idVendor           = 0x16d0,
-	.idProduct          = 0x05a5,
+	.idVendor           = USB_VID,
+	.idProduct          = USB_PID,
 	.bcdDevice          = (_BOARD_REVISION_MAJOR_ << 8) | _BOARD_REVISION_MINOR_,
 
 	.iManufacturer      = 0x01,

--- a/firmware/src/boards/qtpy/apollo_board.h
+++ b/firmware/src/boards/qtpy/apollo_board.h
@@ -13,6 +13,10 @@
 #include <hal/include/hal_gpio.h>
 #include <stdbool.h>
 
+/* pid.codes test VID/PID */
+#define USB_VID 0x1209
+#define USB_PID 0x0010
+
 /**
  * TODO: the qtpy board has a single RGB neopixel.
  */

--- a/firmware/src/boards/raspberry_pi_pico/apollo_board.h
+++ b/firmware/src/boards/raspberry_pi_pico/apollo_board.h
@@ -18,6 +18,10 @@
 #include "hardware/sync.h"
 
 
+/* pid.codes test VID/PID */
+#define USB_VID 0x1209
+#define USB_PID 0x0010
+
 #define __NOP() {asm volatile("nop");}
 
 

--- a/firmware/src/boards/samd11_xplained/apollo_board.h
+++ b/firmware/src/boards/samd11_xplained/apollo_board.h
@@ -14,6 +14,9 @@
 #include <hal/include/hal_gpio.h>
 #include <stdbool.h>
 
+/* pid.codes test VID/PID */
+#define USB_VID 0x1209
+#define USB_PID 0x0010
 
 
 /**

--- a/firmware/src/mcu/rp2040/usb_descriptors.c
+++ b/firmware/src/mcu/rp2040/usb_descriptors.c
@@ -27,6 +27,7 @@
  */
 
 #include "tusb.h"
+#include "apollo_board.h"
 
 #include "pico.h"
 #include "pico/unique_id.h"
@@ -61,9 +62,8 @@ tusb_desc_device_t const desc_device =
 
 	.bMaxPacketSize0    = CFG_TUD_ENDPOINT0_SIZE,
 
-	// These are a unique VID/PID for Apollo.
-	.idVendor           = 0x1d50,
-	.idProduct          = 0x615c,
+	.idVendor           = USB_VID,
+	.idProduct          = USB_PID,
 	.bcdDevice          = (_BOARD_REVISION_MAJOR_ << 8) | _BOARD_REVISION_MINOR_,
 
 	.iManufacturer      = 0x01,

--- a/firmware/src/mcu/samd11/usb_descriptors.c
+++ b/firmware/src/mcu/samd11/usb_descriptors.c
@@ -28,6 +28,7 @@
 #include "tusb.h"
 #include "board_rev.h"
 #include "usb/usb_protocol.h"
+#include "apollo_board.h"
 
 enum
 {
@@ -56,9 +57,8 @@ tusb_desc_device_t desc_device =
 
 	.bMaxPacketSize0    = CFG_TUD_ENDPOINT0_SIZE,
 
-	// These are a unique VID/PID for Apollo.
-	.idVendor           = 0x1d50,
-	.idProduct          = 0x615c,
+	.idVendor           = USB_VID,
+	.idProduct          = USB_PID,
 
 	.iManufacturer      = STRING_INDEX_MANUFACTURER,
 	.iProduct           = STRING_INDEX_PRODUCT,

--- a/misc/54-apollo.rules
+++ b/misc/54-apollo.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="000f", SYMLINK+="flash-bridge-%k", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="0010", SYMLINK+="apollo-%k", TAG+="uaccess"


### PR DESCRIPTION
Implements part of the plan in #86