### PR TITLE
On Windows, create the libusb1 backend explicitly by specifying the installed location of libusb-1.0.dll

### DIFF
--- a/apollo_fpga/gateware/flash_bridge.py
+++ b/apollo_fpga/gateware/flash_bridge.py
@@ -34,7 +34,7 @@ MAX_BULK_PACKET_SIZE = 512
 class SPIStreamController(Elaboratable):
     """ Class that drives a SPI bus with data from input stream packets.
     Data received from the device is returned as another packet."""
-    
+
     def __init__(self):
         self.period = 4  # powers of two only
         self.bus    = SPIBus()
@@ -56,7 +56,7 @@ class SPIStreamController(Elaboratable):
             sck_fall.eq( sck_d & ~self.bus.sck),  # falling edge
             sck_rise.eq(~sck_d &  self.bus.sck),  # rising edge
         ]
-        
+
         # I/O shift registers, bit counter and last flag
         shreg_o = Signal(8)
         shreg_i = Signal(8)
@@ -114,7 +114,7 @@ class SPIStreamController(Elaboratable):
                             m.next = 'END'
                         with m.Elif(~self.input.valid):
                             m.next = 'WAIT'
-            
+
             with m.State("END"):
                 m.d.comb += [
                     self.input.ready    .eq(0),
@@ -134,7 +134,7 @@ class SPIStreamController(Elaboratable):
             ]
 
         return m
-    
+
 
 class FlashBridgeRequestHandler(USBRequestHandler):
     """ Request handler that can trigger a FPGA reconfiguration. """
@@ -168,7 +168,7 @@ class FlashBridgeRequestHandler(USBRequestHandler):
 
                     # Once the receive is complete, respond with an ACK.
                     with m.If(interface.rx_ready_for_response):
-                        m.d.comb += interface.handshakes_out.ack.eq(1)    
+                        m.d.comb += interface.handshakes_out.ack.eq(1)
 
                     # If we reach the status stage, send a ZLP.
                     with m.If(interface.status_requested):
@@ -181,7 +181,7 @@ class FlashBridgeRequestHandler(USBRequestHandler):
 class FlashBridgeSubmodule(Elaboratable):
     """ Implements gateware for the USB<->SPI bridge. Intended to use as a submodule
         See example in FlashBridge """
-    
+
     def __init__(self, endpoint):
         # Endpoint number for the in/out stream endpoints
         self.endpoint = endpoint
@@ -354,12 +354,15 @@ class FlashBridgeNotFound(IOError):
 class FlashBridgeConnection:
     def __init__(self):
         # Try to create a connection to our configuration flash bridge.
-        device = usb.core.find(idVendor=VENDOR_ID, idProduct=PRODUCT_ID, custom_match=self._find_cfg_flash_bridge)
+        device = ApolloDebugger._find_device(
+            ids=[(VENDOR_ID, PRODUCT_ID)],
+            custom_match=self._find_cfg_flash_bridge
+        )
 
         # If we couldn't find the bridge, bail out.
         if device is None:
             raise FlashBridgeNotFound("Unable to find device")
-        
+
         self.device = device
         self.interface, self.endpoint = self._find_cfg_flash_bridge(device, get_ep=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     'Topic :: Scientific/Engineering',
 ]
 dependencies = [
+    "importlib_resources; python_version<'3.9'",
     "pyusb>1.1.1",
     "pyvcd>=0.2.4",
     "prompt-toolkit>3.0.16",


### PR DESCRIPTION
On Windows the `usb1` Python package installs the libusb1 dll within the `usb1` module directory but can not locate it to create a backend unless the module directory is added to the system `PATH` environment variable. 

This PR modifies the `ApolloDebugger._find_device()` static method to, on Windows, obtain the backend by passing the location of the installed `libusb-1.0.dll` to `libusb1.get_backend()` and then passing that backend to `usb.core.find()`.

This PR also modifies the other usage of `usb.core.find()` in `FlashBridgeConnection`to use `ApolloDebugger._find_device()` instead.

It's important to note that, for future work on Apollo, the `usb.core.find()` method should no longer be used if Windows compatibility is to be maintained!

This is a companion PR to the one in Cynthion: https://github.com/greatscottgadgets/cynthion/pull/129
