### PR TITLE
apollo_fpga: Add optional timeout to `ApolloDebugger._find_device`

### DIFF
--- a/apollo_fpga/commands/cli.py
+++ b/apollo_fpga/commands/cli.py
@@ -204,9 +204,6 @@ def program_flash_fast(device, args):
     # Let the LUNA gateware take over in devices with shared USB port
     device.allow_fpga_takeover_usb()
 
-    # Wait for flash bridge enumeration
-    time.sleep(2)
-
     # Program SPI flash memory using the configured bridge
     bridge = FlashBridgeConnection()
     programmer = ECP5FlashBridgeProgrammer(bridge=bridge)

--- a/apollo_fpga/gateware/flash_bridge.py
+++ b/apollo_fpga/gateware/flash_bridge.py
@@ -356,7 +356,8 @@ class FlashBridgeConnection:
         # Try to create a connection to our configuration flash bridge.
         device = ApolloDebugger._find_device(
             ids=[(VENDOR_ID, PRODUCT_ID)],
-            custom_match=self._find_cfg_flash_bridge
+            custom_match=self._find_cfg_flash_bridge,
+            timeout=5000
         )
 
         # If we couldn't find the bridge, bail out.


### PR DESCRIPTION
As PyUSB does not provide a way to wait for a device, we simulate it with periodic sleeps. If we move to libusb1 at some point we can get rid of this.

Fixes greatscottgadgets/cynthion#142.