### PR TITLE
Remove py_ci installation option

### DIFF
--- a/.github/workflows/host.yml
+++ b/.github/workflows/host.yml
@@ -32,5 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         pdm install -G :all
+        pdm add amaranth==0.4.1
+        pdm add luna-usb~=0.1
     - name: Run tests
       run: pdm run test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,6 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[project.optional-dependencies]
-py_ci = [
-    "amaranth==0.4.1",
-    "luna-usb~=0.1",
-]
-
 [project.urls]
 repository = "https://github.com/greatscottgadgets/apollo"
 issues     = "https://github.com/greatscottgadgets/apollo/issues"


### PR DESCRIPTION
This works around a pdm bug (#3271) and removes a "Provides-Extra" listing on PyPI.